### PR TITLE
Add initial reusable workflows and dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @reedloden @russjones @adaadb6

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/csv-lint.yaml
+++ b/.github/workflows/csv-lint.yaml
@@ -1,0 +1,42 @@
+name: Lint (CSV)
+
+on:
+  workflow_call:
+
+jobs:
+  csvlint:
+      name: csvlint
+      runs-on: ubuntu-latest
+
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v19
+        with:
+          files: |
+            **/*.csv
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.17.9'
+
+      - name: Checkout csvlint
+        uses: actions/checkout@v3
+        with:
+          repository: Clever/csvlint
+          path: csvlint
+
+      - name: csvlint
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          cd csvlint
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "Validating ${file}"
+            go run cmd/csvlint/main.go ../${file}
+          done

--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -1,0 +1,44 @@
+name: Lint (Terraform)
+
+on:
+  workflow_call:
+
+# TODO: Add job for `terraform validate`
+jobs:
+  terraform-fmt:
+      name: terraform fmt
+      runs-on: ubuntu-latest
+
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: terraform fmt
+        run: terraform fmt -no-color -check -diff -recursive
+  tfsec:
+      name: tfsec
+      runs-on: ubuntu-latest
+
+      permissions:
+        actions: read
+        contents: read
+        pull-requests: write
+        security-events: write
+
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: tfsec
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
+        with:
+          github_token: ${{ github.token }}
+          tfsec_formats: sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: results.sarif.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# shared-workflows
-GitHub Actions shared within the organization
+# Teleport Shared GitHub Actions Workflows
+
+GitHub Actions shared within the `gravitational` organization.
+
+To use one of these workflows:
+
+```yaml
+jobs:
+  call-workflow-passing-data:
+    uses: gravitational/shared-workflows/.github/workflows/reusable-workflow.yml@main
+    secrets: inherit
+```


### PR DESCRIPTION
* Add reusable workflows for CSV and Terraform linting
* Add Dependabot config to keep GitHub Actions up-to-date (via weekly PRs as needed)
* Add CODEOWNERS to protect workflows
* Update README to provide example on how to use a reusable workflow