### PR TITLE
Explicitly set the permissions for each job

### DIFF
--- a/.github/workflows/csv-lint.yaml
+++ b/.github/workflows/csv-lint.yaml
@@ -8,6 +8,9 @@ jobs:
       name: csvlint
       runs-on: ubuntu-latest
 
+      permissions:
+        contents: read
+
       steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -9,6 +9,9 @@ jobs:
       name: terraform fmt
       runs-on: ubuntu-latest
 
+      permissions:
+        contents: read
+
       steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
* For the avoidance of doubt, set permissions for each workflow job.