### PR TITLE
Add a shared workflow for validating JSON

### DIFF
--- a/.github/workflows/json-lint.yaml
+++ b/.github/workflows/json-lint.yaml
@@ -1,0 +1,33 @@
+name: Lint (JSON)
+
+on:
+  workflow_call:
+
+jobs:
+  jsonlint:
+      name: jsonlint
+      runs-on: ubuntu-latest
+
+      permissions:
+        contents: read
+
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v24
+        with:
+          files: |
+            **/*.json
+
+      - name: jsonlint
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "Validating ${file}"
+            jq empty ${file}
+          done


### PR DESCRIPTION
This adds a shared workflow for usage in `github-terraform` and any other repos that want to use it

Validated that `jq empty filename` will return a non-zero exit code and fail the pipeline for invalid JSON

![image](https://user-images.githubusercontent.com/7922109/182640020-a8e9b837-858a-48e4-a3bc-8f77e58db8f2.png)

`jq` is installed on `ubuntu-latest` by default - https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md

This completes https://github.com/gravitational/github-terraform/pull/197