### PR TITLE
Add GitHub's dependency-review-action as a linter

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,32 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull
+# Request, surfacing known-vulnerable versions of the packages declared or
+# updated in the PR. Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency Review'
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_call:
+
+jobs:
+  dependency-review:
+    name: 'Dependency Review'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v2
+        with:
+          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, OFL-1.1, Unlicense


### PR DESCRIPTION
Dependency Review Action

This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.

Source repository: https://github.com/actions/dependency-review-action
Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement