### PR TITLE
CLOUD RFD-0029: Support running against teleport *and* cloud repos

### DIFF
--- a/bot/internal/bot/assign.go
+++ b/bot/internal/bot/assign.go
@@ -76,7 +76,7 @@ func (b *Bot) getReviewers(ctx context.Context, files []github.PullRequestFile) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return b.c.Review.Get(*b.c.Environment, docs, code, files), nil
+	return b.c.Review.Get(b.c.Environment, docs, code, files), nil
 }
 
 func (b *Bot) backportReviewers(ctx context.Context) ([]string, error) {

--- a/bot/internal/bot/assign.go
+++ b/bot/internal/bot/assign.go
@@ -76,7 +76,7 @@ func (b *Bot) getReviewers(ctx context.Context, files []github.PullRequestFile) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return b.c.Review.Get(b.c.Environment.Author, docs, code, files), nil
+	return b.c.Review.Get(*b.c.Environment, docs, code, files), nil
 }
 
 func (b *Bot) backportReviewers(ctx context.Context) ([]string, error) {

--- a/bot/internal/bot/check.go
+++ b/bot/internal/bot/check.go
@@ -91,7 +91,7 @@ func (b *Bot) Check(ctx context.Context) error {
 		}
 	}
 
-	if err := b.c.Review.CheckInternal(*b.c.Environment, reviews, docs, code, large); err != nil {
+	if err := b.c.Review.CheckInternal(b.c.Environment, reviews, docs, code, large); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/bot/internal/bot/check.go
+++ b/bot/internal/bot/check.go
@@ -91,7 +91,7 @@ func (b *Bot) Check(ctx context.Context) error {
 		}
 	}
 
-	if err := b.c.Review.CheckInternal(b.c.Environment.Author, reviews, docs, code, large); err != nil {
+	if err := b.c.Review.CheckInternal(*b.c.Environment, reviews, docs, code, large); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -133,7 +133,7 @@ func (r *Assignments) IsInternal(author string) bool {
 }
 
 // Get will return a list of code reviewers for a given author.
-func (r *Assignments) Get(e env.Environment, docs bool, code bool, files []github.PullRequestFile) []string {
+func (r *Assignments) Get(e *env.Environment, docs bool, code bool, files []github.PullRequestFile) []string {
 	var reviewers []string
 	author := e.Author
 
@@ -171,7 +171,7 @@ func (r *Assignments) getDocsReviewers(author string) []string {
 	return reviewers
 }
 
-func (r *Assignments) getCodeReviewers(e env.Environment, files []github.PullRequestFile) []string {
+func (r *Assignments) getCodeReviewers(e *env.Environment, files []github.PullRequestFile) []string {
 	// Obtain full sets of reviewers.
 	setA, setB := r.getCodeReviewerSets(e)
 
@@ -240,7 +240,7 @@ func (r *Assignments) getAdminReviewers(author string) []string {
 	return reviewers
 }
 
-func (r *Assignments) getCodeReviewerSets(e env.Environment) ([]string, []string) {
+func (r *Assignments) getCodeReviewerSets(e *env.Environment) ([]string, []string) {
 	// Internal non-Core contributors get assigned from the admin reviewer set.
 	// Admins will review, triage, and re-assign.
 
@@ -280,7 +280,7 @@ func (r *Assignments) CheckExternal(author string, reviews []github.Review) erro
 // CheckInternal will verify if required reviewers have approved. Checks if
 // docs and if each set of code reviews have approved. Admin approvals bypass
 // all checks.
-func (r *Assignments) CheckInternal(e env.Environment, reviews []github.Review, docs bool, code bool, large bool) error {
+func (r *Assignments) CheckInternal(e *env.Environment, reviews []github.Review, docs bool, code bool, large bool) error {
 	log.Printf("Check: Found internal author %v.", e.Author)
 
 	// Skip checks if admins have approved.
@@ -336,7 +336,7 @@ func (r *Assignments) checkDocsReviews(author string, reviews []github.Review) e
 	return trace.BadParameter("requires at least one approval from %v", reviewers)
 }
 
-func (r *Assignments) checkCodeReviews(e env.Environment, reviews []github.Review) error {
+func (r *Assignments) checkCodeReviews(e *env.Environment, reviews []github.Review) error {
 	// External code reviews should never hit this path, if they do, fail and
 	// return an error.
 	author := e.Author

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -135,7 +135,6 @@ func (r *Assignments) IsInternal(author string) bool {
 // Get will return a list of code reviewers for a given author.
 func (r *Assignments) Get(e *env.Environment, docs bool, code bool, files []github.PullRequestFile) []string {
 	var reviewers []string
-	author := e.Author
 
 	// TODO: consider existing review assignments here
 	// https://github.com/gravitational/teleport/issues/10420
@@ -143,18 +142,18 @@ func (r *Assignments) Get(e *env.Environment, docs bool, code bool, files []gith
 	switch {
 	case docs && code:
 		log.Printf("Assign: Found docs and code changes.")
-		reviewers = append(reviewers, r.getDocsReviewers(author)...)
+		reviewers = append(reviewers, r.getDocsReviewers(e.Author)...)
 		reviewers = append(reviewers, r.getCodeReviewers(e, files)...)
 	case !docs && code:
 		log.Printf("Assign: Found code changes.")
 		reviewers = append(reviewers, r.getCodeReviewers(e, files)...)
 	case docs && !code:
 		log.Printf("Assign: Found docs changes.")
-		reviewers = append(reviewers, r.getDocsReviewers(author)...)
+		reviewers = append(reviewers, r.getDocsReviewers(e.Author)...)
 	// Strange state, an empty commit? Return admin reviewers.
 	case !docs && !code:
 		log.Printf("Assign: Found no docs or code changes.")
-		reviewers = append(reviewers, r.getAdminReviewers(author)...)
+		reviewers = append(reviewers, r.getAdminReviewers(e.Author)...)
 	}
 
 	return reviewers

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -252,8 +252,7 @@ func (r *Assignments) getCodeReviewerSets(e *env.Environment) ([]string, []strin
 
 	team := v.Team
 
-	// Cloud gets reviewers assigned from Core in Teleport
-	// Core gets reviewers assigned from Cloud in Cloud
+	// Teams do their own internal reviews
 	switch e.Repository {
 	case teleportRepo:
 		team = coreTeam

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -304,7 +304,7 @@ func TestGetCodeReviewers(t *testing.T) {
 			// checking for approvals. This means the bot did not reject the PR
 			// as an external author.
 
-			e := env.Environment{
+			e := &env.Environment{
 				Repository: test.repository,
 				Author:     test.author,
 			}
@@ -802,7 +802,7 @@ func TestCheckInternal(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			e := env.Environment{
+			e := &env.Environment{
 				Repository: test.repository,
 				Author:     test.author,
 			}
@@ -917,7 +917,7 @@ func TestPreferredReviewers(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			e := env.Environment{
+			e := &env.Environment{
 				Author: test.author,
 			}
 			actual := assignments.getCodeReviewers(e, test.files)


### PR DESCRIPTION
Should be a no-op for gravitational/teleport.

Just flips logic around for some review logic when in 'cloud' repo vs. 'teleport'