### PR TITLE
Limit classify changes to Teleport repo

### DIFF
--- a/bot/internal/bot/assign.go
+++ b/bot/internal/bot/assign.go
@@ -72,7 +72,7 @@ func (b *Bot) getReviewers(ctx context.Context, files []github.PullRequestFile) 
 		log.Printf("Assign: Found backport PR, but failed to find original reviewers: %v. Falling through to normal assignment logic.", err)
 	}
 
-	docs, code, err := classifyChanges(files)
+	docs, code, err := classifyChanges(b.c.Environment, files)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -120,13 +120,18 @@ func New(c *Config) (*Bot, error) {
 
 // classifyChanges determines whether the PR contains code changes
 // and/or docs changes.
-func classifyChanges(files []github.PullRequestFile) (docs bool, code bool, err error) {
-	for _, file := range files {
-		if strings.HasPrefix(file.Name, "docs/") {
-			docs = true
-		} else {
-			code = true
+func classifyChanges(e *env.Environment, files []github.PullRequestFile) (docs bool, code bool, err error) {
+	switch e.Repository {
+	case env.TeleportRepo:
+		for _, file := range files {
+			if strings.HasPrefix(file.Name, "docs/") {
+				docs = true
+			} else {
+				code = true
+			}
 		}
+	default:
+		code = true
 	}
 	return docs, code, nil
 }

--- a/bot/internal/bot/bot_test.go
+++ b/bot/internal/bot/bot_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/gravitational/shared-workflows/bot/internal/env"
 	"github.com/gravitational/shared-workflows/bot/internal/github"
 
 	"github.com/stretchr/testify/require"
@@ -67,9 +68,10 @@ func TestClassifyChanges(t *testing.T) {
 			code:  false,
 		},
 	}
+	e := &env.Environment{Repository: env.TeleportRepo}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			docs, code, err := classifyChanges(test.files)
+			docs, code, err := classifyChanges(e, test.files)
 			require.NoError(t, err)
 			require.Equal(t, docs, test.docs)
 			require.Equal(t, code, test.code)

--- a/bot/internal/bot/check.go
+++ b/bot/internal/bot/check.go
@@ -63,7 +63,7 @@ func (b *Bot) Check(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	docs, code, err := classifyChanges(files)
+	docs, code, err := classifyChanges(b.c.Environment, files)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/bot/internal/env/env.go
+++ b/bot/internal/env/env.go
@@ -25,6 +25,17 @@ import (
 	"github.com/gravitational/trace"
 )
 
+const (
+	// Repo slugs
+	CloudRepo    = "cloud"
+	TeleportRepo = "teleport"
+
+	// Teams
+	CoreTeam     = "Core"
+	CloudTeam    = "Cloud"
+	InternalTeam = "Internal"
+)
+
 // Environment is the execution environment the workflow is running in.
 type Environment struct {
 	// Organization is the GitHub organization (gravitational).

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -244,7 +244,7 @@ func (r *Assignments) getCodeReviewerSets(e *env.Environment) ([]string, []strin
 	// Admins will review, triage, and re-assign.
 
 	v, ok := r.c.CodeReviewers[e.Author]
-	if !ok || v.Team == internalTeam {
+	if !ok || v.Team == env.InternalTeam {
 		reviewers := r.getAdminReviewers(e.Author)
 		n := len(reviewers) / 2
 		return reviewers[:n], reviewers[n:]
@@ -254,10 +254,10 @@ func (r *Assignments) getCodeReviewerSets(e *env.Environment) ([]string, []strin
 
 	// Teams do their own internal reviews
 	switch e.Repository {
-	case teleportRepo:
-		team = coreTeam
-	case cloudRepo:
-		team = cloudTeam
+	case env.TeleportRepo:
+		team = env.CoreTeam
+	case env.CloudRepo:
+		team = env.CloudTeam
 	}
 
 	return getReviewerSets(e.Author, team, r.c.CodeReviewers, r.c.CodeReviewersOmit)
@@ -350,10 +350,10 @@ func (r *Assignments) checkCodeReviews(e *env.Environment, reviews []github.Revi
 
 	// Teams do their own internal reviews
 	switch e.Repository {
-	case teleportRepo:
-		team = coreTeam
-	case cloudRepo:
-		team = cloudTeam
+	case env.TeleportRepo:
+		team = env.CoreTeam
+	case env.CloudRepo:
+		team = env.CloudTeam
 	default:
 		return trace.Wrap(fmt.Errorf("unsupported repository: %s", e.Repository))
 	}
@@ -440,12 +440,4 @@ const (
 	Approved = "APPROVED"
 	// ChangesRequested is a code review where the reviewer has requested changes.
 	ChangesRequested = "CHANGES_REQUESTED"
-
-	// Repo slugs
-	cloudRepo    = "cloud"
-	teleportRepo = "teleport"
-
-	coreTeam     = "Core"
-	cloudTeam    = "Cloud"
-	internalTeam = "Internal"
 )


### PR DESCRIPTION
The `classifyChanges` function determines whether a file path includes `/docs` and chooses different reviewers. This should only apply to the Teleport repo.

In order to support a repo comparison, the repo and teams constants were moved from the review package to the env package.