### PR TITLE
Prevent cloud repo from being considered for doc reviews

### DIFF
--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -136,6 +136,12 @@ func (r *Assignments) IsInternal(author string) bool {
 func (r *Assignments) Get(e *env.Environment, docs bool, code bool, files []github.PullRequestFile) []string {
 	var reviewers []string
 
+	// Never consider cloud repo for doc reviews.
+	if e.Repository == cloudRepo {
+		log.Printf("Assign: Found cloud changes.")
+		return r.getCodeReviewers(e, files)
+	}
+
 	// TODO: consider existing review assignments here
 	// https://github.com/gravitational/teleport/issues/10420
 


### PR DESCRIPTION
Had [this](https://github.com/gravitational/cloud/actions/runs/3176524772/jobs/5175922757) failure happen when making changes to the `docs` directory in the cloud repo.