### PR TITLE
Treat dependabot as an internal contributor

### DIFF
--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -31,6 +31,10 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// Dependabot is the GitHub's bot author/account name.
+// See https://github.com/dependabot.
+const Dependabot = "dependabot"
+
 // Reviewer is a code reviewer.
 type Reviewer struct {
 	// Team the reviewer belongs to.
@@ -127,6 +131,11 @@ func New(c *Config) (*Assignments, error) {
 
 // IsInternal returns if the author of a PR is internal.
 func (r *Assignments) IsInternal(author string) bool {
+	// Dependabot is considered an internal contributor.
+	if author == Dependabot {
+		return true
+	}
+
 	_, code := r.c.CodeReviewers[author]
 	_, docs := r.c.DocsReviewers[author]
 	return code || docs

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -117,11 +117,19 @@ func TestIsInternal(t *testing.T) {
 			author: "7",
 			expect: false,
 		},
+		{
+			desc: "dependabot is internal",
+			assignments: &Assignments{
+				c: &Config{},
+			},
+			author: Dependabot,
+			expect: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			expect := test.assignments.IsInternal(test.author)
-			require.Equal(t, expect, test.expect)
+			got := test.assignments.IsInternal(test.author)
+			require.Equal(t, test.expect, got)
 		})
 	}
 }


### PR DESCRIPTION
This allows dependabot to follow the "regular" review cycle, making its dependency update PRs more practical to work with.