### PR TITLE
bot: Only owners of the current repo are candidates

### DIFF
--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -399,7 +399,17 @@ func getReviewerSets(e *env.Environment, team string, reviewers map[string]Revie
 			continue
 		}
 
-		if v.Owner {
+		team := v.Team
+
+		switch e.Repository {
+		case env.TeleportRepo:
+			team = env.CoreTeam
+		case env.CloudRepo:
+			team = env.CloudTeam
+		}
+
+		// Only owners of the current repo are candidates
+		if v.Owner && v.Team == team {
 			setA = append(setA, k)
 		} else {
 			setB = append(setB, k)

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -399,7 +399,10 @@ func TestGetDocsReviewers(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			reviewers := test.assignments.getDocsReviewers(test.author)
+			e := &env.Environment{
+				Author: test.author,
+			}
+			reviewers := test.assignments.getDocsReviewers(e)
 			require.ElementsMatch(t, reviewers, test.reviewers)
 		})
 	}


### PR DESCRIPTION
Currently, the `owner: true` flag is per-user, ignoring whatever team that user belongs to. This causes owners to be added to the required reviewers list across repos, it shouldn't.