### PR TITLE
Mark CHANGELOG changes as docs only

### DIFF
--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -124,7 +124,8 @@ func classifyChanges(e *env.Environment, files []github.PullRequestFile) (docs b
 	switch e.Repository {
 	case env.TeleportRepo:
 		for _, file := range files {
-			if strings.HasPrefix(file.Name, "docs/") {
+			if strings.HasPrefix(file.Name, "docs/") ||
+				file.Name == "CHANGELOG.md" {
 				docs = true
 			} else {
 				code = true

--- a/bot/internal/bot/bot_test.go
+++ b/bot/internal/bot/bot_test.go
@@ -48,6 +48,7 @@ func TestClassifyChanges(t *testing.T) {
 			desc: "docs-only",
 			files: []github.PullRequestFile{
 				{Name: "docs/docs.md"},
+				{Name: "CHANGELOG.md"},
 			},
 			docs: true,
 			code: false,


### PR DESCRIPTION
Currently, changes to `CHANGELOG.md` are treated as code changes.

PRs to the docs in `gravitational/teleport` often need to edit `CHANGELOG.md` as well, since `docs/pages/changelog.mdx` includes `CHANGELOG.md` as a partial, and it's often necessary to, say, fix links in `CHANGELOG.md` in order to get the docs linter to pass.

If `CHANGELOG.md` is treated as a code change, docs PRs that edit this file need to get two more approvals in order to be merged, even if they don't touch any of the `gravitational/teleport` code.

This change treats `CHANGELOG.md` as a special case for determining that a PR is a docs PR. Other Markdown files outside of `docs/` still require code approval, since the assumption is that these are only relevant to the Engineering team.