### PR TITLE
Revert "Bump aquasecurity/tfsec-pr-commenter-action from 1.2.0 to 1.3.0"

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: tfsec
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.3.0
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
         with:
           github_token: ${{ github.token }}
           tfsec_formats: sarif


### PR DESCRIPTION
Reverts gravitational/shared-workflows#34 due to https://github.com/aquasecurity/tfsec-pr-commenter-action/issues/85.