### PR TITLE
dependency-review: Add additional approved licenses

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -29,4 +29,21 @@ jobs:
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v2
         with:
-          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, OFL-1.1, Unlicense
+          allow-licenses:
+            - (MIT OR Apache-2.0) AND Unicode-DFS-2016
+            - Apache-2.0
+            - Apache-2.0 OR MIT
+            - Apache-2.0/ISC/MIT
+            - BSD-2-Clause
+            - BSD-2-Clause-FreeBSD
+            - BSD-3-Clause
+            - CC0-1.0
+            - ISC
+            - LGPL-2.1
+            - MIT
+            - MIT OR Apache-2.0
+            - MIT/Apache-2.0
+            - MPL-2.0
+            - OFL-1.1
+            - Unicode-DFS-2016
+            - Unlicense


### PR DESCRIPTION
Add a few more licenses, as well as the SPDX full strings for some licenses, as the currently released version of `dependency-review-action` does not parse SPDX licenses correctly.

Note that this can be cleaned-up once
https://github.com/actions/dependency-review-action/pull/294 is released.