### PR TITLE
dependency-review: Fix syntax and add additional licenses

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -27,23 +27,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v2
+        uses: actions/dependency-review-action@7a42af0f2fb2fcaa5aa954358f1aac58436bedec
         with:
-          allow-licenses:
-            - (MIT OR Apache-2.0) AND Unicode-DFS-2016
-            - Apache-2.0
-            - Apache-2.0 OR MIT
-            - Apache-2.0/ISC/MIT
-            - BSD-2-Clause
-            - BSD-2-Clause-FreeBSD
-            - BSD-3-Clause
-            - CC0-1.0
-            - ISC
-            - LGPL-2.1
-            - MIT
-            - MIT OR Apache-2.0
-            - MIT/Apache-2.0
-            - MPL-2.0
-            - OFL-1.1
-            - Unicode-DFS-2016
-            - Unlicense
+          allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, OFL-1.1, Unicode-DFS-2016, Unlicense


### PR DESCRIPTION
The syntax I previously attempted failed, so reverting to space-deliminated licenses.

Additionally, add a few more licenses that we are OK with.