### PR TITLE
Expand CODEOWNERS to cover the entire repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.github/ @reedloden @russjones @adaadb6 @wadells
+* @gravitational/dev-eng-leads @gravitational/security-team


### PR DESCRIPTION
Also just use dev-eng-leads and security-team as the approvers.