### PR TITLE
backport: don't request reviews from bots

### DIFF
--- a/bot/internal/bot/assign_test.go
+++ b/bot/internal/bot/assign_test.go
@@ -58,7 +58,7 @@ func TestBackportReviewers(t *testing.T) {
 				UnsafeBody:  "",
 				Fork:        false,
 			},
-			reviewers: []string{"3"},
+			reviewers: []string{"3", "this is a bot[bot]"},
 			reviews: []github.Review{
 				{Author: "4", State: review.Approved},
 			},


### PR DESCRIPTION
When requesting reviewers, we attempt to request reviews from those who reviewed the original PR. This can fail because the CodeQL scanner shows up as a reviewer.

Filter out bots by looking for '[bot]' in the reviewer name. This catches CodeQL and dependatbot, the two bots we have running at the time of this commit.