### PR TITLE
Fix for incorrectly assigning bots as reviewers

### DIFF
--- a/bot/internal/bot/assign.go
+++ b/bot/internal/bot/assign.go
@@ -115,7 +115,10 @@ func (b *Bot) backportReviewers(ctx context.Context) ([]string, error) {
 		return nil, trace.Wrap(err)
 	}
 	for _, review := range reviews {
-		originalReviewers = append(originalReviewers, review.Author)
+		// don't request reviews from bots
+		if !strings.Contains(review.Author, "[bot]") {
+			originalReviewers = append(originalReviewers, review.Author)
+		}
 	}
 
 	return dedup(b.c.Environment.Author, originalReviewers), nil

--- a/bot/internal/bot/assign_test.go
+++ b/bot/internal/bot/assign_test.go
@@ -85,6 +85,26 @@ func TestBackportReviewers(t *testing.T) {
 			expected: []string{"3", "4"},
 		},
 		{
+			desc: "backport-reviewed-by-bot",
+			pull: github.PullRequest{
+				Author:     "baz",
+				Repository: "bar",
+				UnsafeHead: github.Branch{
+					Ref: "baz/fix",
+				},
+				UnsafeTitle: "Fixed an issue",
+				UnsafeBody:  "https://github.com/gravitational/teleport/pull/0",
+				Fork:        false,
+			},
+			reviewers: []string{"3"},
+			reviews: []github.Review{
+				{Author: "4", State: review.Approved},
+				{Author: "espa[bot]lini", State: review.Approved},
+			},
+			err:      false,
+			expected: []string{"3", "4"},
+		},
+		{
 			desc: "backport-multiple-reviews",
 			pull: github.PullRequest{
 				Author:     "baz",


### PR DESCRIPTION
The previous check handles cases where bots were assigned as reviewers, but failed to check for cases where bots had actually submitted reviews.