### PR TITLE
Dependency-Review defaults update

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@11310527b429536e263dc6cc47873e608189ba21
+        uses: actions/dependency-review-action@v3
         with:
           fail-on-severity: moderate
           allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, OFL-1.1, Unicode-DFS-2016, Unlicense

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches:
       - main
+      - master
   workflow_call:
 
 jobs:
@@ -29,4 +30,5 @@ jobs:
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@11310527b429536e263dc6cc47873e608189ba21
         with:
+          fail-on-severity: moderate
           allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, OFL-1.1, Unicode-DFS-2016, Unlicense

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -12,7 +12,6 @@ on:
   pull_request:
     branches:
       - main
-      - master
   workflow_call:
 
 jobs:


### PR DESCRIPTION
Update dependency-review to also by default include the `master` branch.  In addition the minimal severity for failing was raised to moderate.

I think this will allow most projects to accept this configuration without modification.