### PR TITLE
Attempting to allow the Unicode license for rdp-rp

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -30,4 +30,4 @@ jobs:
         uses: actions/dependency-review-action@v3
         with:
           fail-on-severity: moderate
-          allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, OFL-1.1, Unicode-DFS-2016, Unlicense
+          allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, OFL-1.1, Unicode-DFS-2016, Unlicense, (MIT OR Apache-2.0) AND Unicode-DFS-2016


### PR DESCRIPTION
Currently this is failing even though all the licenses are listed as acceptable.  This commit attempts to add the exact license configuration needed by the dependent library `unicode-ident`.