### PR TITLE
Add MIT/Apache-2.0 license combo for dependency-review

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -30,4 +30,4 @@ jobs:
         uses: actions/dependency-review-action@v3
         with:
           fail-on-severity: moderate
-          allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, OFL-1.1, Unicode-DFS-2016, Unlicense, (MIT OR Apache-2.0) AND Unicode-DFS-2016
+          allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, OFL-1.1, Unicode-DFS-2016, Unlicense, (MIT OR Apache-2.0) AND Unicode-DFS-2016,MIT/Apache-2.0


### PR DESCRIPTION
This licnse format looks to be needed by rdp-rs for oid-registry and toml.