### PR TITLE
Consult GitHub org membership when identifying internal authors

### DIFF
--- a/bot/internal/bot/backport.go
+++ b/bot/internal/bot/backport.go
@@ -38,7 +38,11 @@ import (
 // Backport will create backport Pull Requests (if requested) when a Pull
 // Request is merged.
 func (b *Bot) Backport(ctx context.Context) error {
-	if !b.c.Review.IsInternal(b.c.Environment.Author) {
+	internal, err := b.isInternal(ctx)
+	if err != nil {
+		return trace.Wrap(err, "checking for internal author")
+	}
+	if !internal {
 		return trace.BadParameter("automatic backports are only supported for internal contributors")
 	}
 

--- a/bot/internal/bot/check.go
+++ b/bot/internal/bot/check.go
@@ -39,7 +39,11 @@ func (b *Bot) Check(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	if !b.c.Review.IsInternal(b.c.Environment.Author) {
+	internal, err := b.isInternal(ctx)
+	if err != nil {
+		return trace.Wrap(err, "checking for internal author")
+	}
+	if !internal {
 		if err := b.c.Review.CheckExternal(b.c.Environment.Author, reviews); err != nil {
 			return trace.Wrap(err)
 		}

--- a/bot/internal/github/github.go
+++ b/bot/internal/github/github.go
@@ -489,6 +489,27 @@ func (c *Client) DeleteWorkflowRun(ctx context.Context, organization string, rep
 	return nil
 }
 
+// IsOrgMember checks whether [user] is a member of [org].
+//
+// https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+func (c *Client) IsOrgMember(ctx context.Context, user string, org string) (bool, error) {
+	url := url.URL{
+		Scheme: "https",
+		Host:   "api.github.com",
+		Path:   path.Join("orgs", org, "members", user),
+	}
+	req, err := c.client.NewRequest(http.MethodGet, url.String(), nil)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	resp, err := c.client.Do(ctx, req, nil)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	return resp.StatusCode == http.StatusNoContent, nil
+}
+
 // CreateComment will leave a comment on an Issue or Pull Request.
 func (c *Client) CreateComment(ctx context.Context, organization string, repository string, number int, comment string) error {
 	_, _, err := c.client.Issues.CreateComment(ctx,

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -133,7 +133,8 @@ func New(c *Config) (*Assignments, error) {
 	}, nil
 }
 
-// IsInternal returns if the author of a PR is internal.
+// IsInternal checks whether the author of a PR is explicitly
+// listed as an internal code or docs reviewer.
 func (r *Assignments) IsInternal(author string) bool {
 	if isAllowedRobot(author) {
 		return true


### PR DESCRIPTION
If a PR author is not explicitly listed as an internal author in the reviewers secret, check whether the author is a member of the GitHub org.

This prevents us from having to maintain (and offboard) a list of every internal author, which is especially useful for employees from sales and CS who occaisonally submit PRs.