### PR TITLE
Fix an issue that prevents check from succeeding for external authors

### DIFF
--- a/bot/internal/github/github.go
+++ b/bot/internal/github/github.go
@@ -502,7 +502,15 @@ func (c *Client) IsOrgMember(ctx context.Context, user string, org string) (bool
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
+
 	resp, err := c.client.Do(ctx, req, nil)
+	// the go-github API returns an error if the request completed
+	// succesfully but returned a non-200 response code, so we attempt
+	// to check the response before checking the error
+	if resp != nil && resp.StatusCode != 0 {
+		return resp.StatusCode == http.StatusNoContent, nil
+	}
+
 	if err != nil {
 		return false, trace.Wrap(err)
 	}


### PR DESCRIPTION
The Go GitHub API that we use returns an error for repsonses with an HTTP status code not in the 200-299 range. This caused us to return an error rather than assume the user is an external author.

I noticed this when reviewing the logs of a recent run: https://github.com/gravitational/teleport/actions/runs/4018334113/jobs/6903826941