### PR TITLE
Fix checks for internal authors

### DIFF
--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -316,7 +316,7 @@ func TestGetCodeReviewers(t *testing.T) {
 				Repository: test.repository,
 				Author:     test.author,
 			}
-			require.ErrorContains(t, test.assignments.checkCodeReviews(e, nil),
+			require.ErrorContains(t, test.assignments.checkInternalCodeReviews(e, nil),
 				"at least one approval required from each set")
 
 			setA, setB := test.assignments.getCodeReviewerSets(e)


### PR DESCRIPTION
The previous version of the code was checking whether the author was an external contributor twice, but the 2nd check happened at a level where we don't have enough information.

The 2nd check is not necessary, since it only occurs in the code path that is taken for internal authors. This commit includes a rename to make it clear that these methods are used for checking PRs from employees.

See https://github.com/gravitational/teleport/actions/runs/4029084130/jobs/6926613982 for an example run (prior to this fix) that correctly identifies an internal author and then changes its mind and thinks the author is external.