### PR TITLE
Recognize DependabotBatcher as an internal author

### DIFF
--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -31,12 +31,17 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// Dependabot is the GitHub's bot author/account name.
-// See https://github.com/dependabot.
-const Dependabot = "dependabot[bot]"
+const (
+	// Dependabot is the GitHub's bot author/account name.
+	// See https://github.com/dependabot.
+	Dependabot = "dependabot[bot]"
+	// DependabotBatcher is the name of the batcher that groups Dependabot PRs.
+	// See https://github.com/Legal-and-General/dependabot-batcher.
+	DependabotBatcher = "dependabot-batcher[bot]"
+)
 
 func isAllowedRobot(author string) bool {
-	return author == Dependabot
+	return author == Dependabot || author == DependabotBatcher
 }
 
 // Reviewer is a code reviewer.

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -125,6 +125,14 @@ func TestIsInternal(t *testing.T) {
 			author: Dependabot,
 			expect: true,
 		},
+		{
+			desc: "dependabot batcher is internal",
+			assignments: &Assignments{
+				c: &Config{},
+			},
+			author: DependabotBatcher,
+			expect: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
@@ -818,6 +826,24 @@ func TestCheckInternal(t *testing.T) {
 			desc:       "core-dependabot-code-approval-success",
 			repository: "teleport",
 			author:     Dependabot,
+			reviews: []github.Review{
+				{Author: "3", State: Approved}, // owner (not admin)
+				{Author: "4", State: Approved}, // not owner
+			},
+			code:   true,
+			result: true,
+		},
+		{
+			desc:       "core-dependabot-batcher-code-not-approved-failure",
+			repository: "teleport",
+			author:     DependabotBatcher,
+			code:       true,
+			result:     false,
+		},
+		{
+			desc:       "core-dependabot-batcher-code-approval-success",
+			repository: "teleport",
+			author:     DependabotBatcher,
 			reviews: []github.Review{
 				{Author: "3", State: Approved}, // owner (not admin)
 				{Author: "4", State: Approved}, // not owner


### PR DESCRIPTION
Updates `isAllowedRobot` to be either Dependabot or DependabotBatcher so that batched Dependabot PRs don't requrie code owner approval.