### PR TITLE
Covered paths for preferred reviewers

### DIFF
--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -916,8 +916,8 @@ func TestPreferredReviewers(t *testing.T) {
 		c: &Config{
 			Rand: &randStatic{},
 			CodeReviewers: map[string]Reviewer{
-				"1": {Team: "Core", Owner: true, PreferredReviewerFor: []string{"lib/srv/db"}},
-				"2": {Team: "Core", Owner: true, PreferredReviewerFor: []string{"lib/srv/db", "lib/alpn"}},
+				"1": {Team: "Core", Owner: true, PreferredReviewerFor: []string{"lib/srv/db", "lib/srv/app"}},
+				"2": {Team: "Core", Owner: true, PreferredReviewerFor: []string{"lib/srv/db", "lib/src/app", "lib/alpn"}},
 				"3": {Team: "Core", Owner: true},
 				"4": {Team: "Core", Owner: false, PreferredReviewerFor: []string{"lib/srv/app"}},
 				"5": {Team: "Core", Owner: false, PreferredReviewerFor: []string{"lib/srv/db"}},
@@ -953,9 +953,9 @@ func TestPreferredReviewers(t *testing.T) {
 			author:      "3",
 			files: []github.PullRequestFile{
 				{Name: "lib/alpn/proxy.go"},
-				{Name: "lib/srv/db/engine.go"},
+				{Name: "lib/srv/app.go"},
 			},
-			expected: []string{"1", "2", "5"},
+			expected: []string{"1", "2", "4"},
 		},
 		{
 			description: "no preferred reviewers",
@@ -964,6 +964,15 @@ func TestPreferredReviewers(t *testing.T) {
 				{Name: "lib/service/service.go"},
 			},
 			expected: []string{"1", "4"},
+		},
+		{
+			description: "covered paths: don't add new or duplicate reviewers for paths already covered",
+			author:      "3",
+			files: []github.PullRequestFile{
+				{Name: "lib/srv/app.go"},
+				{Name: "lib/srv/db/engine.go"},
+			},
+			expected: []string{"1", "4", "5"},
 		},
 	}
 

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -917,7 +917,7 @@ func TestPreferredReviewers(t *testing.T) {
 			Rand: &randStatic{},
 			CodeReviewers: map[string]Reviewer{
 				"1": {Team: "Core", Owner: true, PreferredReviewerFor: []string{"lib/srv/db", "lib/srv/app"}},
-				"2": {Team: "Core", Owner: true, PreferredReviewerFor: []string{"lib/srv/db", "lib/src/app", "lib/alpn"}},
+				"2": {Team: "Core", Owner: true, PreferredReviewerFor: []string{"lib/srv/db", "lib/alpn"}},
 				"3": {Team: "Core", Owner: true},
 				"4": {Team: "Core", Owner: false, PreferredReviewerFor: []string{"lib/srv/app"}},
 				"5": {Team: "Core", Owner: false, PreferredReviewerFor: []string{"lib/srv/db"}},


### PR DESCRIPTION
Patch the review bot's preferred reviewers logic to prevent it from choosing too many reviewers. This change will not evaluate a path if that path has already been covered by a previously picked reviewer.

The current preferred reviewers implementation adds a reviewer for each unique path defined in the reviews.json file if that path is included in the change set. This can result in either the same reviewers being added multiple times, which Github dedups for us, or adds far too many reviewers when there are a large number of preferred paths in the change set.

Examples 
`2023/02/02 16:46:41 Assign: Requesting reviews from: [michellescripts sclevine sclevine michellescripts michellescripts dilchenko sclevine dboslee justinas evanfreed mcbattirola andreiko dboslee mcbattirola]`

`github-actions bot requested review from dboslee, dilchenko, logand22, mcbattirola, michellescripts and sclevine last week`
