### PR TITLE
Removed admin reviewers with in omit list.

### DIFF
--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -253,10 +253,15 @@ func (r *Assignments) getPreferredReviewersMap(set []string) map[string][]string
 	return m
 }
 
+// getAdminReviewers returns the list of admin reviewers. Respects code
+// reviewer omits and removes admins in omit list from reviews.
 func (r *Assignments) getAdminReviewers(author string) []string {
 	var reviewers []string
 	for _, v := range r.c.Admins {
 		if v == author {
+			continue
+		}
+		if _, ok := r.c.CodeReviewersOmit[v]; ok {
 			continue
 		}
 		reviewers = append(reviewers, v)
@@ -292,7 +297,7 @@ func (r *Assignments) getCodeReviewerSets(e *env.Environment) ([]string, []strin
 func (r *Assignments) CheckExternal(author string, reviews []github.Review) error {
 	log.Printf("Check: Found external author %q.", author)
 
-	reviewers := r.getAdminReviewers(author)
+	reviewers := r.getAdminCheckers(author)
 
 	if checkN(reviewers, reviews) > 1 {
 		return nil
@@ -307,13 +312,13 @@ func (r *Assignments) CheckInternal(e *env.Environment, reviews []github.Review,
 	log.Printf("Check: Found internal author %v.", e.Author)
 
 	// Skip checks if admins have approved.
-	if check(r.getAdminReviewers(e.Author), reviews) {
+	if check(r.getAdminCheckers(e.Author), reviews) {
 		return nil
 	}
 
 	if code && large {
 		log.Println("Check: Detected large PR, requiring admin approval")
-		if !check(r.getAdminReviewers(e.Author), reviews) {
+		if !check(r.getAdminCheckers(e.Author), reviews) {
 			return trace.BadParameter("this PR is large and requires admin approval to merge")
 		}
 	}
@@ -340,7 +345,7 @@ func (r *Assignments) CheckInternal(e *env.Environment, reviews []github.Review,
 	// Strange state, an empty commit? Check admins.
 	case !docs && !code:
 		log.Printf("Check: Found no docs or code changes.")
-		if checkN(r.getAdminReviewers(e.Author), reviews) < 2 {
+		if checkN(r.getAdminCheckers(e.Author), reviews) < 2 {
 			return trace.BadParameter("requires two admin approvals")
 		}
 	}
@@ -386,6 +391,18 @@ func (r *Assignments) checkInternalCodeReviews(e *env.Environment, reviews []git
 	}
 
 	return trace.BadParameter("at least one approval required from each set %v %v", setA, setB)
+}
+
+// getAdminCheckers returns list of admins approvers.
+func (r *Assignments) getAdminCheckers(author string) []string {
+	var reviewers []string
+	for _, v := range r.c.Admins {
+		if v == author {
+			continue
+		}
+		reviewers = append(reviewers, v)
+	}
+	return reviewers
 }
 
 func getReviewerSets(author string, team string, reviewers map[string]Reviewer, reviewersOmit map[string]bool) ([]string, []string) {

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -313,6 +313,29 @@ func TestGetCodeReviewers(t *testing.T) {
 			setA:       []string{"code-1"},
 			setB:       []string{"code-2"},
 		},
+		{
+			desc: "admins can be omitted from code reviews",
+			assignments: &Assignments{
+				c: &Config{
+					CodeReviewers: map[string]Reviewer{
+						"code-1": {Team: "Core", Owner: true},
+						"code-2": {Team: "Core", Owner: false},
+					},
+					Admins: []string{
+						"code-1",
+						"code-2",
+						"code-3",
+					},
+					CodeReviewersOmit: map[string]bool{
+						"code-1": true,
+					},
+				},
+			},
+			repository: "teleport",
+			author:     "external-1",
+			setA:       []string{"code-2"},
+			setB:       []string{"code-3"},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
@@ -426,11 +449,14 @@ func TestCheckExternal(t *testing.T) {
 				"5": {Team: "Core", Owner: false},
 				"6": {Team: "Core", Owner: false},
 			},
-			CodeReviewersOmit: map[string]bool{},
+			CodeReviewersOmit: map[string]bool{
+				"3": true,
+			},
 			// Default.
 			Admins: []string{
 				"1",
 				"2",
+				"3",
 			},
 		},
 	}
@@ -479,6 +505,15 @@ func TestCheckExternal(t *testing.T) {
 			reviews: []github.Review{
 				{Author: "1", State: Approved},
 				{Author: "2", State: Approved},
+			},
+			result: true,
+		},
+		{
+			desc:   "two-admin-one-non-reviewer-success",
+			author: "5",
+			reviews: []github.Review{
+				{Author: "1", State: Approved},
+				{Author: "3", State: Approved},
 			},
 			result: true,
 		},


### PR DESCRIPTION
Removed admin reviewer assignment if admin is in omit list. This allows creation of admins that can still approve PRs but won't be assigned code reviews.