### PR TITLE
Actually run tfsec

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -36,6 +36,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: tfsec
+        uses: aquasecurity/tfsec-action@v1.0.3
+        with:
+          format: sarif
+
+      - name: tfsec PR Commenter
         uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
It was discovered that we weren't actually running tfsec in this workflow.

Since we are working to migrate to trivy, there might not be a lot of value in merging this, but this commit will be useful for testing and comparing against what tfsec _would_ have found.