### PR TITLE
Set the `trivy` `scan-type`

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.9.1
         with:
+          scan-type: config
           hide-progress: false
           format: sarif
           output: 'trivy-results.sarif'


### PR DESCRIPTION
This option is needed to scan the config files the cloned repository files in the workspace (vs scanning images or remote repos).