### PR TITLE
Backport: fetch Github PR branch instead of head branch

### DIFF
--- a/bot/internal/bot/backport.go
+++ b/bot/internal/bot/backport.go
@@ -214,8 +214,8 @@ func (b *Bot) createBackportBranch(ctx context.Context, organization string, rep
 		log.Printf("Failed to set user.email: %v.", err)
 	}
 
-	// Download base and head from origin (GitHub).
-	if err := git("fetch", "origin", base, pull.UnsafeHead.Ref); err != nil {
+	// Fetch the refs for the base branch and the Github PR.
+	if err := git("fetch", "origin", base, fmt.Sprintf("pull/%d/head", number)); err != nil {
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Each Github pull request can be fetched locally using `git fetch origin pull/<pr>/head`. If we use this instead of fetch the user-defined PR branch in the backport bot, we should be able to re-enable the setting that automatically deletes branches for merged PRs.

I did a quick test locally and `git fetch origin pull/<pr>/head` seems to work fine even on merged PRs with the deleted user branch. 