### PR TITLE
dependency-review: Add option to allow specified GHSAs

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -13,6 +13,12 @@ on:
     branches:
       - main
   workflow_call:
+    inputs:
+      allow-ghsas:
+        description: "Allowed GHSAs. Passed through to dependency-review-action"
+        default: ""
+        required: false
+        type: string
 
 jobs:
   dependency-review:
@@ -31,3 +37,4 @@ jobs:
         with:
           fail-on-severity: moderate
           allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, ODC-By-1.0, OFL-1.1, Unicode-DFS-2016, Unlicense, (MIT OR Apache-2.0) AND Unicode-DFS-2016, Apache-2.0 AND BSD-3-Clause
+          allow-ghsas: ${{ inputs.allow-ghsas }}


### PR DESCRIPTION
In https://github.com/gravitational/teleport-plugins/pull/793, due to import of `gravitational/teleport` which does not conform to Go module versioning standard, dependency review is raising a false positive. I am trying to work around this by ignoring this specific GHSA.

See: https://github.com/gravitational/teleport-plugins/pull/793#issuecomment-1481130877 and https://gravitational.slack.com/archives/C0DF0TPMY/p1679580008353179