### PR TITLE
Skip large PR check for cloud deploy branches

### DIFF
--- a/bot/internal/bot/check.go
+++ b/bot/internal/bot/check.go
@@ -78,7 +78,10 @@ func (b *Bot) Check(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	tooBig := xlargeRequiresAdminApproval(files)
+	var tooBig bool
+	if !b.c.Environment.IsCloudDeployBranch() {
+		tooBig = xlargeRequiresAdminApproval(files)
+	}
 	if tooBig {
 		comment := fmt.Sprintf("@%v - this PR will require admin approval to merge due to its size. "+
 			"Consider breaking it up into a series smaller changes.", b.c.Environment.Author)

--- a/bot/internal/env/env.go
+++ b/bot/internal/env/env.go
@@ -34,6 +34,10 @@ const (
 	CoreTeam     = "Core"
 	CloudTeam    = "Cloud"
 	InternalTeam = "Internal"
+
+	// Cloud Deploy Branches
+	CloudProdBranch    = "prod"
+	CloudStagingBranch = "staging"
 )
 
 // Environment is the execution environment the workflow is running in.
@@ -117,6 +121,13 @@ func New() (*Environment, error) {
 		UnsafeHead:   event.PullRequest.UnsafeHead.UnsafeRef,
 		UnsafeBase:   event.PullRequest.UnsafeBase.UnsafeRef,
 	}, nil
+}
+
+// IsCloudDeployBranch returns true when the environment's repository is cloud
+// and the base branch is a deploy branch (e.g. staging or prod).
+func (e *Environment) IsCloudDeployBranch() bool {
+	return e.Repository == CloudRepo &&
+		(e.UnsafeBase == CloudProdBranch || e.UnsafeBase == CloudStagingBranch)
 }
 
 func readEvent() (*Event, error) {


### PR DESCRIPTION
Most of our PRs for deploying to staging or production are large because they contain multiple PRs from master. Remove the need for admin approval for these cloud deployment branches.