### PR TITLE
Deprecate tfsec

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -21,30 +21,6 @@ jobs:
 
       - name: terraform fmt
         run: terraform fmt -no-color -check -diff -recursive
-  tfsec:
-      name: tfsec
-      runs-on: ubuntu-latest
-
-      permissions:
-        actions: read
-        contents: read
-        pull-requests: write
-        security-events: write
-
-      steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: tfsec
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
-        with:
-          github_token: ${{ github.token }}
-          tfsec_formats: sarif
-
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: results.sarif.json
   tflint:
       name: TFLint
       runs-on: ubuntu-latest


### PR DESCRIPTION
It has been deprecated upstream, and use cases will migrate to using Trivy.