### PR TITLE
Remind docs page authors of easy-to-forget tasks

### DIFF
--- a/bot/internal/bot/bloat_test.go
+++ b/bot/internal/bot/bloat_test.go
@@ -34,15 +34,17 @@ func TestBloat(t *testing.T) {
 
 	cases := []struct {
 		name            string
-		comments        []github.Comment
+		comments        map[int][]github.Comment
 		createArtifacts func(t *testing.T, base, current string)
 		errAssertion    require.ErrorAssertionFunc
 		outAssertion    func(t *testing.T, out string)
 	}{
 		{
 			name: "bloat skipped by admin",
-			comments: []github.Comment{
-				comment("admin1", "/excludebloat three"),
+			comments: map[int][]github.Comment{
+				0: {
+					comment("admin1", "/excludebloat three"),
+				},
 			},
 			createArtifacts: func(t *testing.T, base, current string) {
 				createFileWithSize(t, filepath.Join(base, "one"), 1)
@@ -65,8 +67,10 @@ func TestBloat(t *testing.T) {
 		},
 		{
 			name: "bloat detected",
-			comments: []github.Comment{
-				comment("nonadmin", "/excludebloat three"),
+			comments: map[int][]github.Comment{
+				0: {
+					comment("nonadmin", "/excludebloat three"),
+				},
 			},
 			createArtifacts: func(t *testing.T, base, current string) {
 				createFileWithSize(t, filepath.Join(base, "one"), 1)

--- a/bot/internal/bot/flake_test.go
+++ b/bot/internal/bot/flake_test.go
@@ -25,11 +25,12 @@ func TestSkipFlakes(t *testing.T) {
 	b := &Bot{
 		c: &Config{
 			Environment: &env.Environment{},
-			GitHub: &fakeGithub{comments: []github.Comment{
-				comment("admin1", "/excludeflake TestFoo TestBar"),
-				comment("nonadmin", "/excludeflake TestBaz"),
-				comment("admin2", "/excludeflake TestQuux"),
-			},
+			GitHub: &fakeGithub{comments: map[int][]github.Comment{
+				0: {
+					comment("admin1", "/excludeflake TestFoo TestBar"),
+					comment("nonadmin", "/excludeflake TestBaz"),
+					comment("admin2", "/excludeflake TestQuux"),
+				}},
 			},
 			Review: r,
 		},

--- a/bot/internal/bot/remind.go
+++ b/bot/internal/bot/remind.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bot
+
+import (
+	"context"
+	"strings"
+
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+	"github.com/gravitational/trace"
+)
+
+const newDocsReminderList = `Thanks for writing a new docs page!
+
+Please don't forget to:
+
+- [ ] Read the [Docs Contribution Guide](https://goteleport.com/docs/contributing/documentation/) if you haven't already.
+- [ ] Add backport labels (&#96;backport/branch/v<number>&#96;) for the current and two major Teleport versions (if applicable for your feature) 
+- [ ] Make sure you list any new docs pages in &#96;docs/config.json&#96;.
+- [ ] Document new functionality in a how-to guide, reference docs, and architectural docs (or create new issues to do this later).
+`
+
+const (
+	docsPrefix     = "docs/pages"
+	docsSuffix     = ".mdx"
+	includeSegment = "/includes/"
+)
+
+func (b *Bot) remind(ctx context.Context, number int, files []github.PullRequestFile) error {
+	var newDoc bool
+	for _, file := range files {
+		if !strings.HasPrefix(file.Name, docsPrefix) {
+			continue
+		}
+		if !strings.HasSuffix(file.Name, docsSuffix) {
+			continue
+		}
+		if strings.Contains(file.Name, includeSegment) {
+			continue
+		}
+		if file.Status == github.StatusAdded {
+			newDoc = true
+		}
+	}
+
+	if !newDoc {
+		return nil
+	}
+
+	c, err := b.c.GitHub.ListComments(ctx, b.c.Environment.Organization, b.c.Environment.Repository, number)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// We have already sent the new docs reminder
+	for _, m := range c {
+		if m.Body == newDocsReminderList {
+			return nil
+		}
+	}
+
+	b.c.GitHub.CreateComment(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		number,
+		newDocsReminderList,
+	)
+
+	return nil
+}
+
+// Remind adds reminders to the comments of outstanding pull requests.
+func (b *Bot) Remind(ctx context.Context) error {
+	files, err := b.c.GitHub.ListFiles(
+		ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		b.c.Environment.Number,
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return b.remind(
+		ctx,
+		b.c.Environment.Number,
+		files,
+	)
+}

--- a/bot/internal/bot/remind_test.go
+++ b/bot/internal/bot/remind_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/shared-workflows/bot/internal/env"
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemind(t *testing.T) {
+	cases := []struct {
+		description string
+		files       []github.PullRequestFile
+		// Expect no error if this is empty
+		errSubstring     string
+		expectedComments []string
+		currentComments  []string
+	}{
+		{
+			description: "New docs page",
+			files: []github.PullRequestFile{
+				{
+					Name:      "docs/pages/server-access/new-feature.mdx",
+					Additions: 300,
+					Deletions: 0,
+					Status:    github.StatusAdded,
+				},
+			},
+			errSubstring: "",
+			expectedComments: []string{
+				newDocsReminderList,
+			},
+		},
+		{
+			description: "Minor docs edits",
+			files: []github.PullRequestFile{
+				{
+					Name:      "docs/pages/server-access/introduction.mdx",
+					Additions: 10,
+					Deletions: 2,
+					Status:    github.StatusModified,
+				},
+			},
+			errSubstring:     "",
+			expectedComments: []string{},
+		},
+		{
+			description: "Major docs edits",
+			files: []github.PullRequestFile{
+				{
+					Name:      "docs/pages/server-access/introduction.mdx",
+					Additions: 1000,
+					Deletions: 500,
+					Status:    github.StatusModified,
+				},
+			},
+			errSubstring:     "",
+			expectedComments: []string{},
+		},
+		{
+			description: "New code file",
+			files: []github.PullRequestFile{
+				{
+					Name:      "api/types/jwt.go",
+					Additions: 1000,
+					Status:    github.StatusAdded,
+				},
+			},
+			errSubstring:     "",
+			expectedComments: []string{},
+		},
+		{
+			description: "Moved docs file",
+			files: []github.PullRequestFile{
+				{
+					Name:      "docs/pages/server-access/introduction.mdx",
+					Additions: 1000,
+					Deletions: 500,
+					Status:    github.StatusRenamed,
+				},
+			},
+			errSubstring:     "",
+			expectedComments: []string{},
+		},
+		{
+			description: "New docs page with existing comment",
+			files: []github.PullRequestFile{
+				{
+					Name:      "docs/pages/server-access/new-feature.mdx",
+					Additions: 300,
+					Deletions: 0,
+					Status:    github.StatusAdded,
+				},
+			},
+			expectedComments: []string{
+				newDocsReminderList,
+			},
+			currentComments: []string{
+				newDocsReminderList,
+			},
+		},
+		{
+			description: "New docs partial",
+			files: []github.PullRequestFile{
+				{
+					Name:      "docs/pages/includes/my-partial.mdx",
+					Additions: 300,
+					Deletions: 0,
+					Status:    github.StatusAdded,
+				},
+			},
+			errSubstring:     "",
+			expectedComments: []string{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			prNum := 100
+			b := &Bot{
+				c: &Config{
+					Environment: &env.Environment{},
+					GitHub:      &fakeGithub{},
+				},
+			}
+
+			err := b.remind(context.Background(), prNum, c.files)
+			if c.errSubstring == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, c.errSubstring)
+			}
+
+			m, err := b.c.GitHub.ListComments(context.Background(), "gravitational", "teleport", prNum)
+			assert.NoError(t, err)
+
+			actual := make([]string, len(m))
+			for i, c := range m {
+				actual[i] = c.Body
+			}
+			assert.ElementsMatch(t, c.expectedComments, actual)
+		})
+	}
+}

--- a/bot/internal/bot/skip_test.go
+++ b/bot/internal/bot/skip_test.go
@@ -96,8 +96,12 @@ func TestSkipItems(t *testing.T) {
 			b := &Bot{
 				c: &Config{
 					Environment: &env.Environment{},
-					GitHub:      &fakeGithub{comments: test.comments},
-					Review:      r,
+					GitHub: &fakeGithub{
+						comments: map[int][]github.Comment{
+							0: test.comments,
+						},
+					},
+					Review: r,
 				},
 			}
 			skip, err := b.skipItems(context.Background(), "/testPrefix")

--- a/bot/main.go
+++ b/bot/main.go
@@ -74,6 +74,8 @@ func main() {
 		err = b.ExcludeFlakes(ctx)
 	case "bloat":
 		err = b.BloatCheck(ctx, flags.base, flags.current, flags.artifacts, os.Stdout)
+	case "remind":
+		err = b.Remind(ctx)
 	default:
 		err = trace.BadParameter("unknown workflow: %v", flags.workflow)
 	}


### PR DESCRIPTION
Closes gravitational/teleport#23726
Closes gravitational/teleport#23518

When someone creates a new docs page, there are a few things an author should remember to do that are often easy to forget, even for experienced technical writers.

In this change, if a PR includes a new docs page, the workflow bot will post a comment with a list of items for the docs author to remember to do, e.g., checking the contribution guide (if they haven't already), adding backport labels, editing the navigation sidebar, and updating any references. (There are no reminders for PRs that only edit docs pages.)

Since our Docs Team is currently small, authors of new docs pages are often engineers who contribute infrequently to the docs (since they're focusing on developing features). This change helps these docs contributors remember some important steps without requiring a review from the Docs Team.