### PR TITLE
dependency-review: Additional License Approvals

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -36,5 +36,5 @@ jobs:
         uses: actions/dependency-review-action@v3
         with:
           fail-on-severity: moderate
-          allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, ODC-By-1.0, OFL-1.1, Unicode-DFS-2016, Unlicense, (MIT OR Apache-2.0) AND Unicode-DFS-2016, Apache-2.0 AND BSD-3-Clause
+          allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, ODC-By-1.0, OFL-1.1, Python-2.0, Unicode-DFS-2016, Unlicense, (MIT OR Apache-2.0) AND Unicode-DFS-2016, Apache-2.0 AND BSD-3-Clause, ISC AND MIT
           allow-ghsas: ${{ inputs.allow-ghsas }}


### PR DESCRIPTION
This adds:
* Python-2.0 (used by argparse@2.0.1)
* ISC AND MIT (already allowed individually, used by bcoe/v8-coverage@0.2.3)

Both are needed in Teleport as part of the latest version of Next