### PR TITLE
Add Verify command with Cloud migration check

### DIFF
--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -79,6 +79,12 @@ type Client interface {
 
 	// IsOrgMember checks whether [user] is a member of GitHub orgainzation [org].
 	IsOrgMember(ctx context.Context, user string, org string) (bool, error)
+
+	// GetRef returns a Reference representing the provided ref name.
+	GetRef(ctx context.Context, organization string, repository string, ref string) (github.Reference, error)
+
+	// ListCommitFiles returns all filenames recursively from the tree at a given commit SHA whose prefix matches pathPrefix.
+	ListCommitFiles(ctx context.Context, organization string, repository string, sha string, path string) ([]string, error)
 }
 
 // Config contains configuration for the bot.

--- a/bot/internal/bot/bot_test.go
+++ b/bot/internal/bot/bot_test.go
@@ -229,11 +229,13 @@ func TestDoNotMerge(t *testing.T) {
 }
 
 type fakeGithub struct {
-	files      []github.PullRequestFile
-	pull       github.PullRequest
-	reviewers  []string
-	reviews    []github.Review
-	orgMembers map[string]struct{}
+	files       []github.PullRequestFile
+	pull        github.PullRequest
+	reviewers   []string
+	reviews     []github.Review
+	orgMembers  map[string]struct{}
+	ref         github.Reference
+	commitFiles []string
 }
 
 func (f *fakeGithub) RequestReviewers(ctx context.Context, organization string, repository string, number int, reviewers []string) error {
@@ -303,4 +305,12 @@ func (f *fakeGithub) ListComments(ctx context.Context, organization string, repo
 
 func (f *fakeGithub) CreatePullRequest(ctx context.Context, organization string, repository string, title string, head string, base string, body string, draft bool) (int, error) {
 	return 0, nil
+}
+
+func (f *fakeGithub) GetRef(ctx context.Context, organization string, repository string, ref string) (github.Reference, error) {
+	return f.ref, nil
+}
+
+func (f *fakeGithub) ListCommitFiles(ctx context.Context, organization string, repository string, commitSHA string, pathPrefix string) ([]string, error) {
+	return f.commitFiles, nil
 }

--- a/bot/internal/bot/verify.go
+++ b/bot/internal/bot/verify.go
@@ -1,0 +1,166 @@
+package bot
+
+import (
+	"context"
+	"errors"
+	"log"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/gravitational/shared-workflows/bot/internal/env"
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+	"github.com/gravitational/trace"
+)
+
+// migrationConfig enables the DB migration verification for a repo/path.
+//   map[repo]: [...path]
+var migrationConfig = map[string][]string{
+	env.CloudRepo: []string{"db/salescenter/migrations"},
+}
+
+// Verify is a catch-all for verifying the PR doesn't have any issues.
+// E.g. it is used to verify DB migration files are ordered properly in the Cloud repo.
+func (b *Bot) Verify(ctx context.Context) error {
+	// exec DB migration verification
+	for _, path := range migrationConfig[b.c.Environment.Repository] {
+		err := b.verifyDBMigration(ctx, path)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// verifyDBMigration ensures the DB migration files in a PR have a timestamp
+// that is more recent than the migration files in the base branch.
+func (b *Bot) verifyDBMigration(ctx context.Context, pathPrefix string) error {
+	// get all PR files
+	prFiles, err := b.c.GitHub.ListFiles(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		b.c.Environment.Number)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// no files in the PR? okay then.
+	if len(prFiles) == 0 {
+		log.Print("Verify:cloudDBMigration: no PR files")
+		return nil
+	}
+
+	// parse PR migration file ids
+	// 202301031500_subscription-alter.up.sql => 202301031500
+	prIDs, err := parseMigrationFileIDs(pathPrefix, pullRequestFileNames(prFiles))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// no PR migration files
+	if len(prIDs) == 0 {
+		log.Print("Verify:cloudDBMigration: no migration files in this PR")
+		return nil
+	}
+
+	// get base branch ref
+	branchRef, err := b.c.GitHub.GetRef(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		b.c.Environment.UnsafeBase)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// get base branch migration files
+	branchFiles, err := b.c.GitHub.ListCommitFiles(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		branchRef.SHA,
+		pathPrefix)
+	if err != nil {
+		if errors.Is(err, github.ErrTruncatedTree) {
+			log.Print("Verify:cloudDBMigration: skipping because the tree size is too big")
+			return nil
+		}
+		return trace.Wrap(err)
+	}
+
+	// parse base branch migration file ids
+	branchIDs, err := parseMigrationFileIDs(pathPrefix, branchFiles)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// no base branch migration files
+	if len(branchIDs) == 0 {
+		log.Printf("Verify:cloudDBMigration: no migration files in the base branch: %s", branchRef.Name)
+		return nil
+	}
+
+	// error if the oldest migration file in the PR has an older timestamp
+	// than the most recent migration file in the base branch
+	oldestPRID, newestBranchID := prIDs[0], branchIDs[len(branchIDs)-1]
+	log.Printf("Verify:cloudDBMigration: comparing migration file IDs; PR:%d <= Branch:%d", oldestPRID, newestBranchID)
+	if oldestPRID <= newestBranchID {
+		return trace.Errorf("pull request has an older migration (%d) than the most recent migration file in the %s branch (%d); the name of the migration file needs to be changed to be more recent than %[3]d",
+			oldestPRID, b.c.Environment.UnsafeBase, newestBranchID)
+	}
+
+	return nil
+}
+
+// parseMigrationFileIDs parses each file whose path matches pathPrefix returning
+// the prefix ID of each file or returns an error if the file does not have an
+// integer prefix. The returned IDs are sorted in ascending order.
+//
+//	  202301031500_subscription-alter.up.sql => 202301031500
+func parseMigrationFileIDs(pathPrefix string, files []string) ([]int, error) {
+	var ids []int
+	for _, file := range files {
+		if strings.HasPrefix(file, pathPrefix) {
+			_, f := filepath.Split(file)
+			id, err := parseMigrationFileID(f)
+			if err != nil {
+				return nil, trace.BadParameter("failed to parse migration file %q: %v", file, err)
+			}
+			ids = append(ids, id)
+		}
+	}
+	sort.Ints(ids)
+	return ids, nil
+}
+
+// minMigrationFileID is used to valid migration file timestamps
+const minMigrationFileID = 200000000000
+
+// parseMigrationFileID returns the ID portion of a Cloud DB migration file.
+//
+//	202301031500_subscription-alter.up.sql => 202301031500
+func parseMigrationFileID(file string) (int, error) {
+	x := strings.Index(file, "_")
+	if x == -1 {
+		return 0, trace.BadParameter("no underscore found")
+	}
+
+	id, err := strconv.Atoi(file[:x])
+	if err != nil {
+		return 0, trace.BadParameter("invalid integer prefix: %v", err)
+	}
+
+	if id < minMigrationFileID {
+		return 0, trace.BadParameter("integer prefix is not a valid timestamp")
+	}
+
+	return id, nil
+}
+
+// pullRequestFileNames returns all Name fields from each PullRequestFile.
+func pullRequestFileNames(files []github.PullRequestFile) []string {
+	names := make([]string, len(files))
+	for i := range files {
+		names[i] = files[i].Name
+	}
+	return names
+}

--- a/bot/internal/bot/verify.go
+++ b/bot/internal/bot/verify.go
@@ -132,7 +132,7 @@ func parseMigrationFileIDs(pathPrefix string, files []string) ([]int, error) {
 	return ids, nil
 }
 
-// minMigrationFileID is used to valid migration file timestamps
+// minMigrationFileID is used to validate migration file timestamps
 const minMigrationFileID = 200000000000
 
 // parseMigrationFileID returns the ID portion of a Cloud DB migration file.

--- a/bot/internal/bot/verify_test.go
+++ b/bot/internal/bot/verify_test.go
@@ -1,0 +1,169 @@
+package bot
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/gravitational/shared-workflows/bot/internal/env"
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+)
+
+func TestParseMigrationFileID(t *testing.T) {
+	cases := []struct {
+		file      string
+		expect    int
+		expecterr bool
+	}{
+		{expecterr: true},              // 0
+		{file: "a", expecterr: true},   // 1
+		{file: "a_a", expecterr: true}, // 2
+		{file: strconv.Itoa(minMigrationFileID) + "_", expect: minMigrationFileID}, // 3
+		{file: "202301031500_subscription-alter.up.sql", expect: 202301031500},     // 4
+	}
+	for i, test := range cases {
+		got, err := parseMigrationFileID(test.file)
+		if test.expecterr == (err == nil) {
+			if test.expecterr {
+				t.Fatalf("[%d] expected error", i)
+			} else {
+				t.Fatalf("[%d] unexpected error: %v", i, err)
+			}
+		}
+		if got != test.expect {
+			t.Errorf("[%d] expected %d got %d", i, test.expect, got)
+		}
+	}
+}
+
+func TestParseMigrationFileIDs(t *testing.T) {
+	testFiles := func(path string, prefixes ...int) []string {
+		s := make([]string, len(prefixes))
+		for i := range prefixes {
+			s[i] = path + strconv.Itoa(prefixes[i]) + "_"
+		}
+		return s
+	}
+
+	cases := []struct {
+		path      string
+		files     []string
+		expect    []int
+		expecterr bool
+	}{
+		{ // 0   no files no results or error
+			expecterr: false,
+		},
+		{ // 1   without path
+			path:   "",
+			files:  testFiles("", minMigrationFileID),
+			expect: []int{minMigrationFileID},
+		},
+		{ // 2   with path
+			path:   "a",
+			files:  testFiles("a/", minMigrationFileID),
+			expect: []int{minMigrationFileID},
+		},
+		{ // 3   multiple unordered files returns ordered timestamps
+			path:   "a",
+			files:  testFiles("a/", minMigrationFileID+1, minMigrationFileID),
+			expect: []int{minMigrationFileID, minMigrationFileID + 1},
+		},
+		{ // 4   no timestamp file prefix returns an error
+			path:      "a",
+			files:     []string{"a/_"},
+			expecterr: true,
+		},
+	}
+	for i, test := range cases {
+		got, err := parseMigrationFileIDs(test.path, test.files)
+		if test.expecterr == (err == nil) {
+			if test.expecterr {
+				t.Fatalf("[%d] expected error", i)
+			} else {
+				t.Fatalf("[%d] unexpected error: %v", i, err)
+			}
+		}
+		if len(got) != len(test.expect) {
+			t.Fatalf("[%d] expected %d ids got %d", i, len(test.expect), len(got))
+		}
+		for j := range got {
+			if got[j] != test.expect[j] {
+				t.Errorf("[%d:%d] expected %d got %d", i, j, test.expect[j], got[j])
+			}
+		}
+	}
+}
+
+func TestVerifyCloudDBMigration(t *testing.T) {
+	// load fake github with noop data
+	fgh := &fakeGithub{ref: github.Reference{Name: "foo", SHA: "abc"}}
+	fgh.files = []github.PullRequestFile{{Name: "foo.go"}, {Name: "pkg/lib/foo.go"}}
+	fgh.commitFiles = []string{"foo.go", "pkg/lib/foo.go", "README.md"}
+	bot, err := New(&Config{
+		GitHub: fgh,
+		Environment: &env.Environment{
+			UnsafeBase: "master",
+		},
+	})
+	if err != nil {
+		t.Fatalf("new bot: %v", err)
+	}
+
+	cases := []struct {
+		prFiles     []string
+		branchFiles []string
+		expectErr   bool
+	}{
+		{}, // 0    no migration files in branch or pr
+		{ // 1 OK   no migration files in base branch
+			prFiles: []string{
+				"db/202301031501_adding.up.sql",
+			},
+		},
+		{ // 2 OK   no migration files in PR
+			branchFiles: []string{
+				"db/202301031500_exists.up.sql",
+			},
+		},
+		{ // 3 OK   migration files in PR are newer than base branch
+			prFiles: []string{
+				"db/202301031501_adding.up.sql",
+				"db/202301031501_adding.down.sql",
+			},
+			branchFiles: []string{
+				"db/202301031500_exists.up.sql",
+			},
+		},
+		{ // 4 FAIL  migration files in PR are older than base branch
+			prFiles: []string{
+				"db/202301031500_adding.up.sql",
+				"db/202301031500_adding.down.sql",
+			},
+			branchFiles: []string{
+				"db/202301031501_exists.up.sql",
+			},
+			expectErr: true,
+		},
+	}
+	fghBaseline := *fgh
+	for i, test := range cases {
+		for _, f := range test.prFiles {
+			fgh.files = append(fgh.files, github.PullRequestFile{Name: f})
+		}
+		fgh.commitFiles = append(fgh.commitFiles, test.branchFiles...)
+
+		err = bot.verifyDBMigration(context.Background(), "db")
+		if err != nil {
+			if test.expectErr == (err == nil) {
+				if test.expectErr {
+					t.Fatalf("[%d] expected error", i)
+				} else {
+					t.Fatalf("[%d] unexpected error: %v", i, err)
+				}
+			}
+		}
+
+		*fgh = fghBaseline
+	}
+}

--- a/bot/internal/github/github_test.go
+++ b/bot/internal/github/github_test.go
@@ -1,0 +1,99 @@
+package github
+
+import (
+	"encoding/json"
+	"testing"
+
+	go_github "github.com/google/go-github/v37/github"
+)
+
+func TestFindTreeBlobEntries(t *testing.T) {
+	var tree *go_github.Tree
+	treeJSON := `{
+  "sha": "95d933bddfb5bb9e7b0eeb8fcafb453b9c5ed1d0",
+  "tree": [
+    {
+      "sha": "77ba35c445776f2e076c642cab490bedc85d3282",
+      "path": ".drone.yml",
+      "mode": "100644",
+      "type": "blob",
+      "size": 5307,
+      "url": "https://api.github.com/repos/gravitational/cloud/git/blobs/77ba35c445776f2e076c642cab490bedc85d3282"
+    },
+    {
+      "sha": "862914f5917e2cc713da1147404c53f4102289e9",
+      "path": ".github",
+      "mode": "040000",
+      "type": "tree",
+      "url": "https://api.github.com/repos/gravitational/cloud/git/trees/862914f5917e2cc713da1147404c53f4102289e9"
+    },
+    {
+      "sha": "e7b66702a51d900f0185290d413d6076984b1735",
+      "path": "db/salescenter/migrations/202301031000_product-alter.up.sql",
+      "mode": "100644",
+      "type": "blob",
+      "size": 87,
+      "url": "https://api.github.com/repos/gravitational/cloud/git/blobs/e7b66702a51d900f0185290d413d6076984b1735"
+    },
+    {
+      "sha": "ffb28ae64f4f4fc575b2abd236e22a05f7f57c07",
+      "path": ".github/ISSUE_TEMPLATE",
+      "mode": "040000",
+      "type": "tree",
+      "url": "https://api.github.com/repos/gravitational/cloud/git/trees/ffb28ae64f4f4fc575b2abd236e22a05f7f57c07"
+    },
+    {
+      "sha": "627021ef0ccdc45dd52be3da49cf311d429cffa5",
+      "path": ".github/ISSUE_TEMPLATE/tenant_upgrade.md",
+      "mode": "100644",
+      "type": "blob",
+      "size": 2665,
+      "url": "https://api.github.com/repos/gravitational/cloud/git/blobs/627021ef0ccdc45dd52be3da49cf311d429cffa5"
+    },
+    {
+      "sha": "293bbd2c51c1e63d0424c7756d021ed5b0cb76a3",
+      "path": "db/salescenter/migrations/202301031500_subscription-alter.up.sql",
+      "mode": "100644",
+      "type": "blob",
+      "url": "https://api.github.com/repos/gravitational/cloud/git/trees/293bbd2c51c1e63d0424c7756d021ed5b0cb76a3"
+    }],
+	"truncated": false
+	}`
+	err := json.Unmarshal([]byte(treeJSON), &tree)
+	if err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	cases := []struct {
+		path   string
+		expect []string
+	}{
+		{ // 0
+			path: "",
+			expect: []string{
+				".drone.yml",
+				"db/salescenter/migrations/202301031000_product-alter.up.sql",
+				".github/ISSUE_TEMPLATE/tenant_upgrade.md",
+				"db/salescenter/migrations/202301031500_subscription-alter.up.sql",
+			},
+		},
+		{ // 1
+			path: "db/salescenter/migrations",
+			expect: []string{
+				"db/salescenter/migrations/202301031000_product-alter.up.sql",
+				"db/salescenter/migrations/202301031500_subscription-alter.up.sql",
+			},
+		},
+	}
+	for i, test := range cases {
+		got := findTreeBlobEntries(tree, test.path)
+		if len(got) != len(test.expect) {
+			t.Fatalf("[%d] expected %d items got %d", i, len(test.expect), len(got))
+		}
+		for j := range got {
+			if got[j] != test.expect[j] {
+				t.Errorf("[%d:%d] expected '%s' got '%s'", i, j, test.expect[j], got[j])
+			}
+		}
+	}
+}

--- a/bot/main.go
+++ b/bot/main.go
@@ -66,6 +66,8 @@ func main() {
 		} else {
 			err = b.Backport(ctx)
 		}
+	case "verify":
+		err = b.Verify(ctx)
 	default:
 		err = trace.BadParameter("unknown workflow: %v", flags.workflow)
 	}


### PR DESCRIPTION
Add a new verify command for non-reviewer related checks. Include a DB migration filename verification for cloud.

This PR adds a new "verify" command intended to be used to verify a PR meets certain requirements. I thought about reusing the "check" command but that is intended to be specific to reviewers. There is also an argument for putting repo-specific verifications in the repo itself but keeping it here has the benefit of reusing code, secrets, and configs; and makes it easier to share if/when we want the same verification in multiple repos without having to mess with image publishing and versioning.

The specific check added ensures that migration files added to a PR have a timestamp that is newer than the most recent migration file timestamp in the base branch. This is needed to ensure ordering of migration files is consistent and migrations are not skipped. Otherwise we'd have to enable the migration tool to apply all migration files regardless of order which would create the possibility of failure when applying.

This may cause difficulty when preparing a release candidate for cloud because we don't always include all PRs in the RC. This means we may need to hold the RC until the dependent PR is verified or open a new PR that changes the names of the files. We'll review again once this is in place but the pressing need is to ensure migration files are not skipped.