### PR TITLE
Add workflow to exclude flaky tests

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -72,3 +72,14 @@ See [internal/bot/label.go#L99](internal/bot/label.go#L99) for the complete list
 Will create backport Pull Requests (if requested) when a Pull Request is merged.
 
 The branches targeted by the backports are controlled by the `backport/*` labels
+
+### verify
+
+Checks that the PR meets specific requirements.
+
+For example, ensures that cloud migrations have a valid timestamp.
+
+### exclude-flakes
+
+Looks at PR comments to determine which Go tests can be omitted from flaky
+test detection for the specified PR.

--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -63,7 +63,7 @@ type Client interface {
 	CreateComment(ctx context.Context, organization string, repository string, number int, comment string) error
 
 	// ListComments will list all comments on an Issue or Pull Request.
-	ListComments(ctx context.Context, organization string, repository string, number int) ([]string, error)
+	ListComments(ctx context.Context, organization string, repository string, number int) ([]github.Comment, error)
 
 	// ListWorkflows lists all workflows within a repository.
 	ListWorkflows(ctx context.Context, organization string, repository string) ([]github.Workflow, error)

--- a/bot/internal/bot/bot_test.go
+++ b/bot/internal/bot/bot_test.go
@@ -236,6 +236,7 @@ type fakeGithub struct {
 	orgMembers  map[string]struct{}
 	ref         github.Reference
 	commitFiles []string
+	comments    []github.Comment
 }
 
 func (f *fakeGithub) RequestReviewers(ctx context.Context, organization string, repository string, number int, reviewers []string) error {
@@ -299,8 +300,8 @@ func (f *fakeGithub) CreateComment(ctx context.Context, organization string, rep
 	return nil
 }
 
-func (f *fakeGithub) ListComments(ctx context.Context, organization string, repository string, number int) ([]string, error) {
-	return nil, nil
+func (f *fakeGithub) ListComments(ctx context.Context, organization string, repository string, number int) ([]github.Comment, error) {
+	return f.comments, nil
 }
 
 func (f *fakeGithub) CreatePullRequest(ctx context.Context, organization string, repository string, title string, head string, base string, body string, draft bool) (int, error) {

--- a/bot/internal/bot/check.go
+++ b/bot/internal/bot/check.go
@@ -93,7 +93,14 @@ func (b *Bot) Check(ctx context.Context) error {
 			b.c.Environment.Repository,
 			b.c.Environment.Number,
 		)
-		if !contains(comments, comment) {
+		commentExists := false
+		for _, c := range comments {
+			if c.Body == comment {
+				commentExists = true
+				break
+			}
+		}
+		if !commentExists {
 			if err := b.c.GitHub.CreateComment(ctx,
 				b.c.Environment.Organization,
 				b.c.Environment.Repository,

--- a/bot/internal/bot/flake.go
+++ b/bot/internal/bot/flake.go
@@ -1,0 +1,56 @@
+package bot
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+	"github.com/gravitational/trace"
+)
+
+const skipPrefix = "/excludeflake"
+
+// ExcludeFlakes gets the list of test names that can be
+// excluded from flaky test detection for a particular PR.
+// Admin reviewers can exclude tests by commenting on a
+// PR with "/excludeflake Test1 Test2".
+//
+// The result is written to a GitHub Action output parameter
+// named FLAKE_SKIP.
+func (b *Bot) ExcludeFlakes(ctx context.Context) error {
+	skip, err := b.testsToSkip(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	outfile := os.Getenv(github.OutputEnv)
+	err = os.WriteFile(outfile, []byte("FLAKE_SKIP="+strings.Join(skip, " ")), 0644)
+	return trace.Wrap(err)
+}
+
+func (b *Bot) testsToSkip(ctx context.Context) ([]string, error) {
+	comments, err := b.c.GitHub.ListComments(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		b.c.Environment.Number)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var testsToSkip []string
+
+	admins := b.c.Review.GetAdminCheckers(b.c.Environment.Author)
+	for _, c := range comments {
+		if !contains(admins, c.Author) {
+			continue
+		}
+		if strings.HasPrefix(c.Body, skipPrefix) {
+			for _, testName := range strings.Fields(c.Body)[1:] {
+				testsToSkip = append(testsToSkip, testName)
+			}
+		}
+	}
+
+	return testsToSkip, nil
+}

--- a/bot/internal/bot/flake_test.go
+++ b/bot/internal/bot/flake_test.go
@@ -1,0 +1,94 @@
+package bot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/shared-workflows/bot/internal/env"
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+	"github.com/gravitational/shared-workflows/bot/internal/review"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkipFlakes(t *testing.T) {
+	r, err := review.New(&review.Config{
+		Admins:            []string{"admin1", "admin2"},
+		CodeReviewers:     make(map[string]review.Reviewer),
+		CodeReviewersOmit: make(map[string]bool),
+		DocsReviewers:     make(map[string]review.Reviewer),
+		DocsReviewersOmit: make(map[string]bool),
+	})
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		desc     string
+		comments []github.Comment
+		skip     []string
+	}{
+		{
+			desc:     "empty",
+			comments: nil,
+			skip:     nil,
+		},
+		{
+			desc: "simple",
+			comments: []github.Comment{
+				{Author: "admin1", Body: "/excludeflake TestFoo"},
+			},
+			skip: []string{"TestFoo"},
+		},
+		{
+			desc: "missing test",
+			comments: []github.Comment{
+				{Author: "admin1", Body: "/excludeflake  "},
+			},
+			skip: nil,
+		},
+		{
+			desc: "missing prefix",
+			comments: []github.Comment{
+				{Author: "admin1", Body: "TestFoo TestBar"},
+			},
+			skip: nil,
+		},
+		{
+			desc: "missing test",
+			comments: []github.Comment{
+				{Author: "admin1", Body: "abc"},
+				{Author: "admin2", Body: "def"},
+				{Author: "bob", Body: "ghi"},
+				{Author: "alice", Body: "jkl"},
+			},
+			skip: nil,
+		},
+		{
+			desc: "multiple",
+			comments: []github.Comment{
+				{Author: "admin1", Body: "/excludeflake TestFoo TestBar"},
+			},
+			skip: []string{"TestFoo", "TestBar"},
+		},
+		{
+			desc: "complex",
+			comments: []github.Comment{
+				{Author: "admin1", Body: "/excludeflake TestFoo TestBar"},
+				{Author: "nonadmin", Body: "/excludeflake TestBaz"},
+				{Author: "admin2", Body: "/excludeflake TestQuux"},
+			},
+			skip: []string{"TestFoo", "TestBar", "TestQuux"},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			b := &Bot{
+				c: &Config{
+					Environment: &env.Environment{},
+					GitHub:      &fakeGithub{comments: test.comments},
+					Review:      r,
+				},
+			}
+			skip, err := b.testsToSkip(context.Background())
+			require.NoError(t, err)
+			require.ElementsMatch(t, skip, test.skip)
+		})
+	}
+}

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -296,7 +296,7 @@ func (r *Assignments) getCodeReviewerSets(e *env.Environment) ([]string, []strin
 func (r *Assignments) CheckExternal(author string, reviews []github.Review) error {
 	log.Printf("Check: Found external author %q.", author)
 
-	reviewers := r.getAdminCheckers(author)
+	reviewers := r.GetAdminCheckers(author)
 
 	if checkN(reviewers, reviews) > 1 {
 		return nil
@@ -311,13 +311,13 @@ func (r *Assignments) CheckInternal(e *env.Environment, reviews []github.Review,
 	log.Printf("Check: Found internal author %v.", e.Author)
 
 	// Skip checks if admins have approved.
-	if check(r.getAdminCheckers(e.Author), reviews) {
+	if check(r.GetAdminCheckers(e.Author), reviews) {
 		return nil
 	}
 
 	if code && large {
 		log.Println("Check: Detected large PR, requiring admin approval")
-		if !check(r.getAdminCheckers(e.Author), reviews) {
+		if !check(r.GetAdminCheckers(e.Author), reviews) {
 			return trace.BadParameter("this PR is large and requires admin approval to merge")
 		}
 	}
@@ -344,7 +344,7 @@ func (r *Assignments) CheckInternal(e *env.Environment, reviews []github.Review,
 	// Strange state, an empty commit? Check admins.
 	case !docs && !code:
 		log.Printf("Check: Found no docs or code changes.")
-		if checkN(r.getAdminCheckers(e.Author), reviews) < 2 {
+		if checkN(r.GetAdminCheckers(e.Author), reviews) < 2 {
 			return trace.BadParameter("requires two admin approvals")
 		}
 	}
@@ -392,8 +392,8 @@ func (r *Assignments) checkInternalCodeReviews(e *env.Environment, reviews []git
 	return trace.BadParameter("at least one approval required from each set %v %v", setA, setB)
 }
 
-// getAdminCheckers returns list of admins approvers.
-func (r *Assignments) getAdminCheckers(author string) []string {
+// GetAdminCheckers returns list of admins approvers.
+func (r *Assignments) GetAdminCheckers(author string) []string {
 	var reviewers []string
 	for _, v := range r.c.Admins {
 		if v == author {

--- a/bot/main.go
+++ b/bot/main.go
@@ -68,6 +68,8 @@ func main() {
 		}
 	case "verify":
 		err = b.Verify(ctx)
+	case "exclude-flakes":
+		err = b.ExcludeFlakes(ctx)
 	default:
 		err = trace.BadParameter("unknown workflow: %v", flags.workflow)
 	}


### PR DESCRIPTION
Teleport's flaky test detector looks for new or changed tests, and runs them many times in an attempt to detect flakiness. It's not very smart, so sometimes an inconsequential change to an old test (like renaming a variable or changing a function signature) will result in the detector trying to run a slow test too many times and timing out, blocking the team from merging the change.

This workflow will look at a PR and find /excludeflake comments from admins. This is intended to be used as a prerequisite to the flaky test detector, so that we can omit certain changes from flaky test detection.

Note: the flaky test detector itself lives in the Teleport repo. This will run first and pass output to the flaky test detector step.

See corresponding Teleport PR here: https://github.com/gravitational/teleport/pull/26542