### PR TITLE
Add renovate apps as internal authors

### DIFF
--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -38,10 +38,16 @@ const (
 	// DependabotBatcher is the name of the batcher that groups Dependabot PRs.
 	// See https://github.com/Legal-and-General/dependabot-batcher.
 	DependabotBatcher = "dependabot-batcher[bot]"
+	// RenovateBotPrivate is the name of the app that runs the Renovate action in
+	// private repos(teleport.e).
+	RenovateBotPrivate = "private-renovate-gha[bot]"
+	// RenovateBotPublic is the name of the app that runs the Renovate action in
+	// public repos(teleport).
+	RenovateBotPublic = "renovate-gha[bot]"
 )
 
 func isAllowedRobot(author string) bool {
-	return author == Dependabot || author == DependabotBatcher
+	return author == Dependabot || author == DependabotBatcher || author == RenovateBotPrivate || author == RenovateBotPublic
 }
 
 // Reviewer is a code reviewer.

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -133,6 +133,22 @@ func TestIsInternal(t *testing.T) {
 			author: DependabotBatcher,
 			expect: true,
 		},
+		{
+			desc: "renovate public is internal",
+			assignments: &Assignments{
+				c: &Config{},
+			},
+			author: RenovateBotPublic,
+			expect: true,
+		},
+		{
+			desc: "renovate private is internal",
+			assignments: &Assignments{
+				c: &Config{},
+			},
+			author: RenovateBotPrivate,
+			expect: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {


### PR DESCRIPTION
Updates `isAllowedRobot` to include the public and private apps that are used by the renovate bot that creates dependency update PRs.