### PR TITLE
Use correct name for the public renovate bot

### DIFF
--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -43,7 +43,7 @@ const (
 	RenovateBotPrivate = "private-renovate-gha[bot]"
 	// RenovateBotPublic is the name of the app that runs the Renovate action in
 	// public repos(teleport).
-	RenovateBotPublic = "renovate-gha[bot]"
+	RenovateBotPublic = "public-renovate-gha[bot]"
 )
 
 func isAllowedRobot(author string) bool {


### PR DESCRIPTION
This is an update to https://github.com/gravitational/shared-workflows/pull/119 which was created prior to the public renovate app and used an incorrect name. 