### PR TITLE
Revert "Bump aquasecurity/trivy-action from 0.10.0 to 0.11.2"

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.11.2
+        uses: aquasecurity/trivy-action@0.10.0
         with:
           scan-type: config
           hide-progress: false


### PR DESCRIPTION
Reverts gravitational/shared-workflows#123.  Ever since this merged, Trivy has been failing with the folowing symptom:

```
Error: Code Scanning could not process the submitted SARIF file:
SARIF URI scheme "git" did not match the checkout URI scheme "file", <repeats>
```

https://github.com/gravitational/cloud-terraform/actions/runs/5294843544/jobs/9584603964?pr=2577