### PR TITLE
`dependency-review`: Approve several OSS licenses for new dependencies

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -36,5 +36,5 @@ jobs:
         uses: actions/dependency-review-action@v3
         with:
           fail-on-severity: moderate
-          allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, ODC-By-1.0, OFL-1.1, Python-2.0, Unicode-DFS-2016, Unlicense, (MIT OR Apache-2.0) AND Unicode-DFS-2016, Apache-2.0 AND BSD-3-Clause, ISC AND MIT
+          allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MPL-2.0, ODC-By-1.0, OFL-1.1, Python-2.0, Unicode-DFS-2016, Unlicense, Zlib, (MIT OR Apache-2.0) AND Unicode-DFS-2016, Apache-2.0 AND BSD-3-Clause, ISC AND MIT, MIT AND Zlib, MIT AND BSD-3-Clause
           allow-ghsas: ${{ inputs.allow-ghsas }}


### PR DESCRIPTION
https://gravitational.slack.com/archives/C03P3TY31HR/p1687454139319919

>  yarn.lock » pako@1.0.11 – License: MIT AND Zlib
>  yarn.lock » sha.js@2.4.11 – License: MIT AND BSD-3-Clause

Add the following licenses to the approved list:
* Zlib
* MIT AND Zlib
* MIT AND BSD-3-Clause