### PR TITLE
Fix Github API GetRef call in verify workflow

### DIFF
--- a/bot/internal/bot/verify.go
+++ b/bot/internal/bot/verify.go
@@ -80,7 +80,7 @@ func (b *Bot) verifyDBMigration(ctx context.Context, pathPrefix string) error {
 	branchRef, err := b.c.GitHub.GetRef(ctx,
 		b.c.Environment.Organization,
 		b.c.Environment.Repository,
-		b.c.Environment.UnsafeBase)
+		"heads/"+b.c.Environment.UnsafeBase)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
The Github API requires a prefix in the git ref call to distinguish between branch and tag names. This fixes the verify workflow.