### PR TITLE
`trivy`: Filter git URIs from SARIF

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -27,8 +27,16 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
 
+      - name: Filter SARIF for GitHub
+        uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            -git\\:\\:https\\:/**
+          input: 'trivy-results.sarif'
+          output: 'trivy-results.filtered.sarif'
+
       - name: Upload Trivy scan results to GitHub
         uses: github/codeql-action/upload-sarif@v2
         if: always()
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: 'trivy-results.filtered.sarif'


### PR DESCRIPTION
Addresses gravitational/secops#358

GitHub's code scanning can't handle SARIF locations other than plain repo-relative path strings, which trivy/defsec is emitting now that it is recursively scanning for all possible terraform root modules; filter these results out.