### PR TITLE
Disable Trivy

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -13,4 +13,6 @@ jobs:
         contents: read
         security-events: write
 
-      steps: []
+      steps:
+      - name: Disabled
+        run: "echo 'Trivy disabled: gravitational/SecOps#358'"


### PR DESCRIPTION
An empty steps list isn't supported. Print a message.

gravitational/SecOps#358