### PR TITLE
Update reviewers check for release PRs

### DIFF
--- a/bot/internal/bot/assign.go
+++ b/bot/internal/bot/assign.go
@@ -72,11 +72,8 @@ func (b *Bot) getReviewers(ctx context.Context, files []github.PullRequestFile) 
 		log.Printf("Assign: Found backport PR, but failed to find original reviewers: %v. Falling through to normal assignment logic.", err)
 	}
 
-	docs, code, err := classifyChanges(b.c.Environment, files)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return b.c.Review.Get(b.c.Environment, docs, code, files), nil
+	changes := classifyChanges(b.c.Environment, files)
+	return b.c.Review.Get(b.c.Environment, changes, files), nil
 }
 
 func (b *Bot) backportReviewers(ctx context.Context) ([]string, error) {

--- a/bot/internal/bot/check.go
+++ b/bot/internal/bot/check.go
@@ -73,16 +73,9 @@ func (b *Bot) Check(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	docs, code, err := classifyChanges(b.c.Environment, files)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	changes := classifyChanges(b.c.Environment, files)
 
-	var tooBig bool
-	if !b.c.Environment.IsCloudDeployBranch() {
-		tooBig = xlargeRequiresAdminApproval(files)
-	}
-	if tooBig {
+	if changes.Large {
 		comment := fmt.Sprintf("@%v - this PR will require admin approval to merge due to its size. "+
 			"Consider breaking it up into a series smaller changes.", b.c.Environment.Author)
 
@@ -112,7 +105,7 @@ func (b *Bot) Check(ctx context.Context) error {
 		}
 	}
 
-	if err := b.c.Review.CheckInternal(b.c.Environment, reviews, docs, code, tooBig); err != nil {
+	if err := b.c.Review.CheckInternal(b.c.Environment, reviews, changes); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/bot/internal/env/changes.go
+++ b/bot/internal/env/changes.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package env
+
+// Changes contains classification of the PR changes.
+type Changes struct {
+	// Code indicates the PR contains code changes.
+	Code bool
+	// Docs indicates the PR contains docs changes.
+	Docs bool
+	// Release indicates a release PR.
+	Release bool
+	// Large indicates the PR changeset is large.
+	Large bool
+}

--- a/bot/internal/github/github.go
+++ b/bot/internal/github/github.go
@@ -245,6 +245,32 @@ type PullRequestFile struct {
 	Deletions int
 }
 
+// PullRequestFiles is a list of pull request files.
+type PullRequestFiles []PullRequestFile
+
+// HasFile returns true if the file list contains the specified file.
+func (f PullRequestFiles) HasFile(name string) bool {
+	for _, file := range f {
+		if file.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// SourceFiles returns a list of code source files.
+func (f PullRequestFiles) SourceFiles() (files PullRequestFiles) {
+	sourceSuffixes := []string{".go", ".rs", ".js", ".ts", ".tsx"}
+	for _, file := range f {
+		for _, suffix := range sourceSuffixes {
+			if strings.HasSuffix(file.Name, suffix) {
+				files = append(files, file)
+			}
+		}
+	}
+	return files
+}
+
 // GetPullRequestWithCommits returns the specified pull request with commits.
 func (c *Client) GetPullRequestWithCommits(ctx context.Context, organization string, repository string, number int) (PullRequest, error) {
 	pull, err := c.GetPullRequest(ctx, organization, repository, number)


### PR DESCRIPTION
Update the bot's reviewers check to recognize release PRs (example: https://github.com/gravitational/teleport/pull/29308) and require at least one approval from the release team on them.

This is needed because our internal tool team folks are going to be publishing releases as well now and should be able to approve release PRs without being blocked on the admin approval. With this change, say if Trent is publishing release, he will be able to get an approval from Cam and another engineer (not necessarily on the release team) who are in the same timezone.

The list of release reviewers will be: Trent, Cam, Fred, Roman, Zac and Charn. I will update the [reviewers map](https://github.com/gravitational/github-terraform/blob/main/gravitational/secrets/reviewers.json) with this change before merging this PR.