### PR TITLE
Add binary bloat checking

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -1,0 +1,30 @@
+name: Bloat Check
+on:
+  workflow_call:
+    inputs:
+      base_build_dir:
+        description: "The base directory of artifacts prior to a change"
+        default: ""
+        required: true
+        type: string
+      current_build_dir:
+        description: "The current directory of artifacts including the change"
+        default: ""
+        required: true
+        type: string
+      artifacts:
+        description: "The artifacts in each directory to analyze for bloat"
+        default: ""
+        required: true
+        type: string
+jobs:
+  bloat:
+    name: Bloat Check
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Run bloat check
+        run: go run main.go --artifacts=${{ inputs.artifacts }} --base=${{ inputs.base_build_dir }} --current=${{ inputs.current_build_dir }} > $GITHUB_STEP_SUMMARY

--- a/bot/internal/bot/bloat.go
+++ b/bot/internal/bot/bloat.go
@@ -1,0 +1,177 @@
+package bot
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	// skipBloatCheckPrefix the comment prefix to use in order to
+	// skip particular artifacts from the bloat check.
+	skipBloatCheckPrefix = "/excludebloat"
+	// warnThreshold is the amount of MB that a binary may increase and
+	// only a warning is logged
+	warnThreshold = 1
+	// errorThreshold is the amount of MB that a binary cannot exceed without
+	// failing the check.
+	errorThreshold = 3
+)
+
+// BloatCheck determines if any of the provided artifacts have increased. An error
+// is returned if the artifacts in the current directory exceed the same artifact in
+// the base directory by more than the errorThreshold.
+func (b *Bot) BloatCheck(ctx context.Context, base, current string, artifacts []string, out io.Writer) error {
+	output := make(map[string]result, len(artifacts))
+
+	skip, err := b.skipItems(ctx, skipBloatCheckPrefix)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var failure bool
+	for _, artifact := range artifacts {
+		select {
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err())
+		default:
+		}
+
+		skipped := false
+		for _, s := range skip {
+			if s == artifact {
+				skipped = true
+				break
+			}
+		}
+
+		stats, err := calculateChange(base, current, artifact)
+		if err != nil {
+			return err
+		}
+
+		status := "✅"
+		if skipped {
+			status += " skipped by admin"
+		} else {
+			if stats.diff > int64(warnThreshold) {
+				status = "⚠️"
+			}
+			if stats.diff > int64(errorThreshold) {
+				status = "❌"
+				failure = !skipped
+			}
+		}
+
+		output[artifact] = result{
+			baseSize:    fmt.Sprintf("%dMB", stats.baseSize),
+			currentSize: fmt.Sprintf("%dMB", stats.currentSize),
+			change:      fmt.Sprintf("%dMB %s", stats.diff, status),
+		}
+	}
+
+	if err := renderMarkdownTable(out, output); err != nil {
+		return err
+	}
+
+	if failure {
+		return errors.New("binary bloat detected - at least one binary increased by more than the allowed threshold")
+	}
+
+	return nil
+}
+
+type result struct {
+	baseSize    string
+	currentSize string
+	change      string
+}
+
+func renderMarkdownTable(w io.Writer, data map[string]result) error {
+	titles := []string{"Binary", "Base Size", "Current Size", "Change"}
+
+	// get the initial padding from the titles
+	padding := map[string]int{}
+	for _, v := range titles {
+		padding[v] = len(v)
+	}
+
+	max := func(a, b int) int {
+		if a > b {
+			return a
+		}
+		return b
+	}
+
+	// get the largest item from the title or items in the column to determine
+	// the actual padding
+	for k, column := range data {
+		padding["Binary"] = max(padding["Binary"], len(k))
+		padding["Base Size"] = max(padding["Base Size"], len(column.baseSize))
+		padding["Current Size"] = max(padding["Current Size"], len(column.currentSize))
+		padding["Change"] = max(padding["Change"], utf8.RuneCountInString(column.change))
+	}
+
+	format := strings.Repeat("| %%-%ds ", len(padding)) + "|\n"
+	paddings := []interface{}{
+		padding["Binary"],
+		padding["Base Size"],
+		padding["Current Size"],
+		padding["Change"],
+	}
+	format = fmt.Sprintf(format, paddings...)
+
+	// write the heading and title
+	buf := bytes.NewBufferString("# Bloat Check Results\n")
+	row := []any{"Binary", "Base Size", "Current Size", "Change"}
+	buf.WriteString(fmt.Sprintf(format, row...))
+
+	// write the delimiter
+	row = []interface{}{"", "", "", ""}
+	buf.WriteString(strings.Replace(fmt.Sprintf(format, row...), " ", "-", -1))
+
+	// write the rows
+	for k, column := range data {
+		row := []interface{}{k, column.baseSize, column.currentSize, column.change}
+		buf.WriteString(fmt.Sprintf(format, row...))
+	}
+
+	_, err := w.Write(buf.Bytes())
+	return trace.Wrap(err)
+}
+
+type stats struct {
+	baseSize    int64
+	currentSize int64
+	diff        int64
+}
+
+func calculateChange(base, current, binary string) (stats, error) {
+	baseInfo, err := os.Stat(filepath.Join(base, binary))
+	if err != nil {
+		return stats{}, trace.Wrap(err)
+	}
+
+	currentInfo, err := os.Stat(filepath.Join(current, binary))
+	if err != nil {
+		return stats{}, trace.Wrap(err)
+	}
+
+	// convert from bytes to MB for easier to read output
+	baseMB := baseInfo.Size() / (1 << 20)
+	currentMB := currentInfo.Size() / (1 << 20)
+
+	return stats{
+		baseSize:    baseMB,
+		currentSize: currentMB,
+		diff:        currentMB - baseMB,
+	}, nil
+}

--- a/bot/internal/bot/bloat_test.go
+++ b/bot/internal/bot/bloat_test.go
@@ -1,0 +1,145 @@
+package bot
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gravitational/shared-workflows/bot/internal/env"
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+	"github.com/gravitational/shared-workflows/bot/internal/review"
+	"github.com/stretchr/testify/require"
+)
+
+func createFileWithSize(t *testing.T, path string, sizeInMB int64) {
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(sizeInMB<<20))
+}
+
+func TestBloat(t *testing.T) {
+	r, err := review.New(&review.Config{
+		Admins:            []string{"admin1", "admin2"},
+		CodeReviewers:     make(map[string]review.Reviewer),
+		CodeReviewersOmit: make(map[string]bool),
+		DocsReviewers:     make(map[string]review.Reviewer),
+		DocsReviewersOmit: make(map[string]bool),
+	})
+	require.NoError(t, err)
+
+	base := t.TempDir()
+	current := t.TempDir()
+
+	cases := []struct {
+		name            string
+		comments        []github.Comment
+		createArtifacts func(t *testing.T, base, current string)
+		errAssertion    require.ErrorAssertionFunc
+		outAssertion    func(t *testing.T, out string)
+	}{
+		{
+			name: "bloat skipped by admin",
+			comments: []github.Comment{
+				comment("admin1", "/excludebloat three"),
+			},
+			createArtifacts: func(t *testing.T, base, current string) {
+				createFileWithSize(t, filepath.Join(base, "one"), 1)
+				createFileWithSize(t, filepath.Join(current, "one"), 1)
+
+				createFileWithSize(t, filepath.Join(base, "two"), 1)
+				createFileWithSize(t, filepath.Join(current, "two"), 2)
+
+				createFileWithSize(t, filepath.Join(base, "three"), 1)
+				createFileWithSize(t, filepath.Join(current, "three"), 5)
+			},
+			errAssertion: require.NoError,
+			outAssertion: func(t *testing.T, out string) {
+				require.Equal(t, `        | Binary | Base Size | Current Size | Change                 |
+        |--------|-----------|--------------|------------------------|
+        | two    | 1MB       | 2MB          | 1MB ✅                  |
+        | three  | 1MB       | 5MB          | 4MB ✅ skipped by admin |
+        | one    | 1MB       | 1MB          | 0MB ✅                  |`, out)
+			},
+		},
+		{
+			name: "bloat detected",
+			comments: []github.Comment{
+				comment("nonadmin", "/excludebloat three"),
+			},
+			createArtifacts: func(t *testing.T, base, current string) {
+				createFileWithSize(t, filepath.Join(base, "one"), 1)
+				createFileWithSize(t, filepath.Join(current, "one"), 1)
+
+				createFileWithSize(t, filepath.Join(base, "two"), 1)
+				createFileWithSize(t, filepath.Join(current, "two"), 2)
+
+				createFileWithSize(t, filepath.Join(base, "three"), 1)
+				createFileWithSize(t, filepath.Join(current, "three"), 5)
+			},
+			errAssertion: require.Error,
+			outAssertion: func(t *testing.T, out string) {
+				require.Equal(t, `        | Binary | Base Size | Current Size | Change |
+        |--------|-----------|--------------|--------|
+        | one    | 1MB       | 1MB          | 0MB ✅  |
+        | two    | 1MB       | 2MB          | 1MB ✅  |
+        | three  | 1MB       | 5MB          | 4MB ❌  |`, out)
+			},
+		},
+		{
+			name: "artifact not found",
+			createArtifacts: func(t *testing.T, base, current string) {
+				createFileWithSize(t, filepath.Join(base, "one"), 1)
+				createFileWithSize(t, filepath.Join(current, "one"), 1)
+
+				createFileWithSize(t, filepath.Join(base, "two"), 1)
+				createFileWithSize(t, filepath.Join(current, "two"), 2)
+			},
+			errAssertion: require.Error,
+			outAssertion: func(t *testing.T, out string) {
+				require.Empty(t, out)
+			},
+		},
+		{
+			name: "no bloat",
+			createArtifacts: func(t *testing.T, base, current string) {
+				createFileWithSize(t, filepath.Join(base, "one"), 1)
+				createFileWithSize(t, filepath.Join(current, "one"), 1)
+
+				createFileWithSize(t, filepath.Join(base, "two"), 1)
+				createFileWithSize(t, filepath.Join(current, "two"), 1)
+
+				createFileWithSize(t, filepath.Join(base, "three"), 1)
+				createFileWithSize(t, filepath.Join(current, "three"), 1)
+			},
+			errAssertion: require.NoError,
+			outAssertion: func(t *testing.T, out string) {
+				require.Equal(t, `        | Binary | Base Size | Current Size | Change |
+        |--------|-----------|--------------|--------|
+        | one    | 1MB       | 1MB          | 0MB ✅  |
+        | two    | 1MB       | 1MB          | 0MB ✅  |
+        | three  | 1MB       | 1MB          | 0MB ✅  |`, out)
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			b := &Bot{
+				c: &Config{
+					Environment: &env.Environment{},
+					GitHub:      &fakeGithub{comments: test.comments},
+					Review:      r,
+				},
+			}
+
+			test.createArtifacts(t, base, current)
+
+			// Validate that only the entries excluded by admins exist in the output
+			var out bytes.Buffer
+			test.errAssertion(t, b.BloatCheck(context.Background(), base, current, []string{"one", "two", "three"}, &out))
+		})
+	}
+
+}

--- a/bot/internal/bot/flake.go
+++ b/bot/internal/bot/flake.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
-const skipPrefix = "/excludeflake"
+const skipFlakePrefix = "/excludeflake"
 
 // ExcludeFlakes gets the list of test names that can be
 // excluded from flaky test detection for a particular PR.
@@ -20,7 +20,7 @@ const skipPrefix = "/excludeflake"
 // The result is written to a GitHub Action output parameter
 // named FLAKE_SKIP.
 func (b *Bot) ExcludeFlakes(ctx context.Context) error {
-	skip, err := b.testsToSkip(ctx)
+	skip, err := b.skipItems(ctx, skipFlakePrefix)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -34,37 +34,4 @@ func (b *Bot) ExcludeFlakes(ctx context.Context) error {
 	log.Printf("wrote %q to %v", output, outfile)
 
 	return trace.Wrap(err)
-}
-
-func (b *Bot) testsToSkip(ctx context.Context) ([]string, error) {
-	comments, err := b.c.GitHub.ListComments(ctx,
-		b.c.Environment.Organization,
-		b.c.Environment.Repository,
-		b.c.Environment.Number)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	var testsToSkip []string
-
-	admins := b.c.Review.GetAdminCheckers(b.c.Environment.Author)
-	for _, c := range comments {
-		if !contains(admins, c.Author) {
-			log.Printf("ignoring comment from non-admin %v", c.Author)
-			continue
-		}
-		// non-admins can edit comments from admins, so we only
-		// consider comments that have not been updated
-		if !c.CreatedAt.IsZero() && c.CreatedAt != c.UpdatedAt {
-			log.Printf("ignoring edited comment from %v", c.Author)
-			continue
-		}
-		if strings.HasPrefix(c.Body, skipPrefix) {
-			for _, testName := range strings.Fields(c.Body)[1:] {
-				testsToSkip = append(testsToSkip, testName)
-			}
-		}
-	}
-
-	return testsToSkip, nil
 }

--- a/bot/internal/bot/skip.go
+++ b/bot/internal/bot/skip.go
@@ -1,0 +1,44 @@
+package bot
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// skipItems finds any comments from an admin with the skipFlakePrefix
+// and returns the list of items that may be skipped.
+func (b *Bot) skipItems(ctx context.Context, skipPrefix string) ([]string, error) {
+	comments, err := b.c.GitHub.ListComments(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		b.c.Environment.Number)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var itemsToSkip []string
+
+	admins := b.c.Review.GetAdminCheckers(b.c.Environment.Author)
+	for _, c := range comments {
+		if !contains(admins, c.Author) {
+			log.Printf("ignoring comment from non-admin %v", c.Author)
+			continue
+		}
+		// non-admins can edit comments from admins, so we only
+		// consider comments that have not been updated
+		if !c.CreatedAt.IsZero() && c.CreatedAt != c.UpdatedAt {
+			log.Printf("ignoring edited comment from %v", c.Author)
+			continue
+		}
+		if strings.HasPrefix(c.Body, skipPrefix) {
+			for _, testName := range strings.Fields(c.Body)[1:] {
+				itemsToSkip = append(itemsToSkip, testName)
+			}
+		}
+	}
+
+	return itemsToSkip, nil
+}

--- a/bot/internal/bot/skip_test.go
+++ b/bot/internal/bot/skip_test.go
@@ -1,0 +1,118 @@
+package bot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gravitational/shared-workflows/bot/internal/env"
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+	"github.com/gravitational/shared-workflows/bot/internal/review"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkipItems(t *testing.T) {
+	r, err := review.New(&review.Config{
+		Admins:            []string{"admin1", "admin2"},
+		CodeReviewers:     make(map[string]review.Reviewer),
+		CodeReviewersOmit: make(map[string]bool),
+		DocsReviewers:     make(map[string]review.Reviewer),
+		DocsReviewersOmit: make(map[string]bool),
+	})
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		desc     string
+		comments []github.Comment
+		skip     []string
+	}{
+		{
+			desc:     "empty",
+			comments: nil,
+			skip:     nil,
+		},
+		{
+			desc: "simple",
+			comments: []github.Comment{
+				comment("admin1", "/testPrefix TestFoo"),
+			},
+			skip: []string{"TestFoo"},
+		},
+		{
+			desc: "missing test",
+			comments: []github.Comment{
+				comment("admin1", "/testPrefix  "),
+			},
+			skip: nil,
+		},
+		{
+			desc: "missing prefix",
+			comments: []github.Comment{
+				comment("admin1", "TestFoo TestBar"),
+			},
+			skip: nil,
+		},
+		{
+			desc: "missing test",
+			comments: []github.Comment{
+				comment("admin1", "abc"),
+				comment("admin2", "def"),
+				comment("bob", "ghi"),
+				comment("alice", "jkl"),
+			},
+			skip: nil,
+		},
+		{
+			desc: "multiple",
+			comments: []github.Comment{
+				comment("admin1", "/testPrefix TestFoo TestBar"),
+			},
+			skip: []string{"TestFoo", "TestBar"},
+		},
+		{
+			desc: "complex",
+			comments: []github.Comment{
+				comment("admin1", "/testPrefix TestFoo TestBar"),
+				comment("nonadmin", "/testPrefix TestBaz"),
+				comment("admin2", "/testPrefix TestQuux"),
+			},
+			skip: []string{"TestFoo", "TestBar", "TestQuux"},
+		},
+		{
+			desc: "comment updated",
+			comments: []github.Comment{
+				comment("admin1", "/testPrefix TestFoo"),
+				{
+					Author:    "admin2",
+					Body:      "/testPrefix TestBar",
+					CreatedAt: time.Now().Add(-10 * time.Minute),
+					UpdatedAt: time.Now(),
+				},
+			},
+			skip: []string{"TestFoo"},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			b := &Bot{
+				c: &Config{
+					Environment: &env.Environment{},
+					GitHub:      &fakeGithub{comments: test.comments},
+					Review:      r,
+				},
+			}
+			skip, err := b.skipItems(context.Background(), "/testPrefix")
+			require.NoError(t, err)
+			require.ElementsMatch(t, skip, test.skip)
+		})
+	}
+}
+
+func comment(author, body string) github.Comment {
+	now := time.Now()
+	return github.Comment{
+		Author:    author,
+		Body:      body,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}


### PR DESCRIPTION
A new `bloat` target is added to the bot to determine if binaries before and after a change cause an increase in size. All changes less than +1MB are ignored, a warning is emitted for any changes >=+1MB, and >=+3MB results in an error.

An increase of >=3MB is allowed if an admin leaves a comment on the PR with the prefix `/excludebloat` similar to how flaky tests can be skipped.