### PR TITLE
Prevent GitHub client blocking forever

### DIFF
--- a/bot/internal/bot/bloat_test.go
+++ b/bot/internal/bot/bloat_test.go
@@ -112,7 +112,7 @@ func TestBloatCheck(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			b := &Bot{
 				c: &Config{
-					Environment: &env.Environment{},
+					Environment: &env.Environment{Number: 1},
 					GitHub:      &fakeGithub{comments: test.comments},
 					Review:      r,
 				},

--- a/bot/internal/bot/flake_test.go
+++ b/bot/internal/bot/flake_test.go
@@ -24,7 +24,7 @@ func TestSkipFlakes(t *testing.T) {
 
 	b := &Bot{
 		c: &Config{
-			Environment: &env.Environment{},
+			Environment: &env.Environment{Number: 1},
 			GitHub: &fakeGithub{comments: []github.Comment{
 				comment("admin1", "/excludeflake TestFoo TestBar"),
 				comment("nonadmin", "/excludeflake TestBaz"),

--- a/bot/internal/bot/skip.go
+++ b/bot/internal/bot/skip.go
@@ -8,13 +8,20 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// skipItems finds any comments from an admin with the skipFlakePrefix
+// skipItems finds any comments from an admin with the skipPrefix
 // and returns the list of items that may be skipped.
 func (b *Bot) skipItems(ctx context.Context, skipPrefix string) ([]string, error) {
+	// If the event was not from a PullRequest then there
+	// will be no comments.
+	if b.c.Environment.Number == 0 {
+		return nil, nil
+	}
+
 	comments, err := b.c.GitHub.ListComments(ctx,
 		b.c.Environment.Organization,
 		b.c.Environment.Repository,
-		b.c.Environment.Number)
+		b.c.Environment.Number,
+	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/bot/internal/bot/skip_test.go
+++ b/bot/internal/bot/skip_test.go
@@ -25,14 +25,17 @@ func TestSkipItems(t *testing.T) {
 		desc     string
 		comments []github.Comment
 		skip     []string
+		num      int
 	}{
 		{
 			desc:     "empty",
+			num:      1,
 			comments: nil,
 			skip:     nil,
 		},
 		{
 			desc: "simple",
+			num:  1,
 			comments: []github.Comment{
 				comment("admin1", "/testPrefix TestFoo"),
 			},
@@ -40,6 +43,7 @@ func TestSkipItems(t *testing.T) {
 		},
 		{
 			desc: "missing test",
+			num:  1,
 			comments: []github.Comment{
 				comment("admin1", "/testPrefix  "),
 			},
@@ -47,6 +51,7 @@ func TestSkipItems(t *testing.T) {
 		},
 		{
 			desc: "missing prefix",
+			num:  1,
 			comments: []github.Comment{
 				comment("admin1", "TestFoo TestBar"),
 			},
@@ -54,6 +59,7 @@ func TestSkipItems(t *testing.T) {
 		},
 		{
 			desc: "missing test",
+			num:  1,
 			comments: []github.Comment{
 				comment("admin1", "abc"),
 				comment("admin2", "def"),
@@ -64,6 +70,7 @@ func TestSkipItems(t *testing.T) {
 		},
 		{
 			desc: "multiple",
+			num:  1,
 			comments: []github.Comment{
 				comment("admin1", "/testPrefix TestFoo TestBar"),
 			},
@@ -71,6 +78,7 @@ func TestSkipItems(t *testing.T) {
 		},
 		{
 			desc: "complex",
+			num:  1,
 			comments: []github.Comment{
 				comment("admin1", "/testPrefix TestFoo TestBar"),
 				comment("nonadmin", "/testPrefix TestBaz"),
@@ -80,6 +88,7 @@ func TestSkipItems(t *testing.T) {
 		},
 		{
 			desc: "comment updated",
+			num:  1,
 			comments: []github.Comment{
 				comment("admin1", "/testPrefix TestFoo"),
 				{
@@ -91,11 +100,20 @@ func TestSkipItems(t *testing.T) {
 			},
 			skip: []string{"TestFoo"},
 		},
+		{
+			desc: "not a pr",
+			comments: []github.Comment{
+				comment("admin1", "/testPrefix TestFoo TestBar"),
+				comment("nonadmin", "/testPrefix TestBaz"),
+				comment("admin2", "/testPrefix TestQuux"),
+			},
+			skip: nil,
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			b := &Bot{
 				c: &Config{
-					Environment: &env.Environment{},
+					Environment: &env.Environment{Number: test.num},
 					GitHub:      &fakeGithub{comments: test.comments},
 					Review:      r,
 				},

--- a/bot/internal/github/github.go
+++ b/bot/internal/github/github.go
@@ -34,9 +34,15 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// OutputEnv is the name of the environment variable for
-// output paramters in GitHubActions.
-const OutputEnv = "GITHUB_OUTPUT"
+const (
+	// OutputEnv is the name of the environment variable for
+	// output paramters in GitHubActions.
+	OutputEnv = "GITHUB_OUTPUT"
+
+	// ClientTimeout specifies a time limit for requests made by
+	// the Client.
+	ClientTimeout = 30 * time.Second
+)
 
 type Client struct {
 	client *go_github.Client
@@ -44,11 +50,12 @@ type Client struct {
 
 // New returns a new GitHub Client.
 func New(ctx context.Context, token string) (*Client, error) {
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
+	clt := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}))
+
+	clt.Timeout = ClientTimeout
+
 	return &Client{
-		client: go_github.NewClient(oauth2.NewClient(ctx, ts)),
+		client: go_github.NewClient(clt),
 	}, nil
 }
 


### PR DESCRIPTION
Adds a timeout to the http.Client used by the bot to prevent calls from blocking indefinitely. Also adds a shortcut to the skip check to abort early if the event that triggered the action was not a pull request.