### PR TITLE
Add `bot` to Dependabot for CVE updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/bot"
     open-pull-requests-limit: 0
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/bot"
+    open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     schedule:
       interval: "weekly"
 
-updates:
   - package-ecosystem: "gomod"
     directory: "/bot"
     open-pull-requests-limit: 0


### PR DESCRIPTION
I believe this is why the flagged updates in PR #172 were missed.