### PR TITLE
Allow preferred docs reviewers

### DIFF
--- a/bot/internal/bot/check.go
+++ b/bot/internal/bot/check.go
@@ -105,7 +105,7 @@ func (b *Bot) Check(ctx context.Context) error {
 		}
 	}
 
-	if err := b.c.Review.CheckInternal(b.c.Environment, reviews, changes); err != nil {
+	if err := b.c.Review.CheckInternal(b.c.Environment, reviews, changes, files); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -176,14 +176,14 @@ func (r *Assignments) Get(e *env.Environment, changes env.Changes, files []githu
 	switch {
 	case changes.Docs && changes.Code:
 		log.Printf("Assign: Found docs and code changes.")
-		reviewers = append(reviewers, r.getDocsReviewers(e.Author)...)
+		reviewers = append(reviewers, r.getDocsReviewers(e, files)...)
 		reviewers = append(reviewers, r.getCodeReviewers(e, files)...)
 	case !changes.Docs && changes.Code:
 		log.Printf("Assign: Found code changes.")
 		reviewers = append(reviewers, r.getCodeReviewers(e, files)...)
 	case changes.Docs && !changes.Code:
 		log.Printf("Assign: Found docs changes.")
-		reviewers = append(reviewers, r.getDocsReviewers(e.Author)...)
+		reviewers = append(reviewers, r.getDocsReviewers(e, files)...)
 	// Strange state, an empty commit? Return admin reviewers.
 	case !changes.Docs && !changes.Code:
 		log.Printf("Assign: Found no docs or code changes.")
@@ -197,13 +197,20 @@ func (r *Assignments) getReleaseReviewers() []string {
 	return r.c.ReleaseReviewers
 }
 
-func (r *Assignments) getDocsReviewers(author string) []string {
-	setA, setB := getReviewerSets(author, "Core", r.c.DocsReviewers, r.c.DocsReviewersOmit)
-	reviewers := append(setA, setB...)
+func (r *Assignments) getDocsReviewers(e *env.Environment, files []github.PullRequestFile) []string {
+	// See if any code reviewers are designated preferred reviewers for one of
+	// the changed docs files. If so, add them as docs reviewers.
+	a, b := getReviewerSets(e.Author, "Core", r.c.CodeReviewers, r.c.CodeReviewersOmit)
+	prefCodeReviewers := r.getAllPreferredReviewers(append(a, b...), files)
+
+	// Get the docs reviewer pool, which does not depend on the files
+	// changed by a pull request.
+	docsA, docsB := getReviewerSets(e.Author, "Core", r.c.DocsReviewers, r.c.DocsReviewersOmit)
+	reviewers := append(prefCodeReviewers, append(docsA, docsB...)...)
 
 	// If no docs reviewers were assigned, assign admin reviews.
 	if len(reviewers) == 0 {
-		return r.getAdminReviewers(author)
+		return r.getAdminReviewers(e.Author)
 	}
 	return reviewers
 }
@@ -236,7 +243,8 @@ func (r *Assignments) getCodeReviewers(e *env.Environment, files []github.PullRe
 }
 
 // getPreferredReviewers returns a list of reviewers that would be preferrable
-// to review the provided changeset.
+// to review the provided changeset. Returns at most one preferred reviewer per
+// file path.
 func (r *Assignments) getPreferredReviewers(set []string, files []github.PullRequestFile) (preferredReviewers []string) {
 	// To avoid assigning too many reviewers iterate over paths that we have
 	// preferred reviewers for and see if any of them are among the changeset.
@@ -255,6 +263,21 @@ func (r *Assignments) getPreferredReviewers(set []string, files []github.PullReq
 				}
 				break
 			}
+		}
+	}
+	return preferredReviewers
+}
+
+// getAllPreferredReviewers returns a list of reviewers that would be
+// preferrable to review the provided changeset. Includes all preferred
+// reviewers for each file path in the chagne set.
+func (r *Assignments) getAllPreferredReviewers(set []string, files []github.PullRequestFile) (preferredReviewers []string) {
+	for path, reviewers := range r.getPreferredReviewersMap(set) {
+		for _, file := range files {
+			if !strings.HasPrefix(file.Name, path) {
+				continue
+			}
+			preferredReviewers = append(preferredReviewers, reviewers...)
 		}
 	}
 	return preferredReviewers
@@ -327,7 +350,7 @@ func (r *Assignments) CheckExternal(author string, reviews []github.Review) erro
 // CheckInternal will verify if required reviewers have approved. Checks if
 // docs and if each set of code reviews have approved. Admin approvals bypass
 // all checks.
-func (r *Assignments) CheckInternal(e *env.Environment, reviews []github.Review, changes env.Changes) error {
+func (r *Assignments) CheckInternal(e *env.Environment, reviews []github.Review, changes env.Changes, files []github.PullRequestFile) error {
 	log.Printf("Check: Found internal author %v.", e.Author)
 
 	// Skip checks if admins have approved.
@@ -354,7 +377,7 @@ func (r *Assignments) CheckInternal(e *env.Environment, reviews []github.Review,
 	switch {
 	case changes.Docs && changes.Code:
 		log.Printf("Check: Found docs and code changes.")
-		if err := r.checkInternalDocsReviews(e.Author, reviews); err != nil {
+		if err := r.checkInternalDocsReviews(e, reviews, files); err != nil {
 			return trace.Wrap(err)
 		}
 		if err := r.checkInternalCodeReviews(e, reviews); err != nil {
@@ -367,7 +390,7 @@ func (r *Assignments) CheckInternal(e *env.Environment, reviews []github.Review,
 		}
 	case changes.Docs && !changes.Code:
 		log.Printf("Check: Found docs changes.")
-		if err := r.checkInternalDocsReviews(e.Author, reviews); err != nil {
+		if err := r.checkInternalDocsReviews(e, reviews, files); err != nil {
 			return trace.Wrap(err)
 		}
 	// Strange state, an empty commit? Check admins.
@@ -396,8 +419,8 @@ func (r *Assignments) checkInternalReleaseReviews(reviews []github.Review) error
 
 // checkInternalDocsReviews checks whether docs review requirements are satisfied
 // for a PR authored by an internal employee
-func (r *Assignments) checkInternalDocsReviews(author string, reviews []github.Review) error {
-	reviewers := r.getDocsReviewers(author)
+func (r *Assignments) checkInternalDocsReviews(e *env.Environment, reviews []github.Review, files []github.PullRequestFile) error {
+	reviewers := r.getDocsReviewers(e, files)
 
 	if check(reviewers, reviews) {
 		return nil

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -504,6 +504,24 @@ func TestGetDocsReviewers(t *testing.T) {
 			},
 			reviewers: []string{"1", "2"},
 		},
+		{
+			desc: "preferred code reviewer for docs page with duplicate code reviewers",
+			assignments: &Assignments{
+				c: &Config{
+
+					CodeReviewers: map[string]Reviewer{
+						"2": {Team: "Core", Owner: true, PreferredReviewerFor: []string{"server-access", "database-access"}},
+						"3": {Team: "Core", Owner: true, PreferredReviewerFor: []string{"server-access", "database-access"}},
+					},
+				},
+			},
+			author: "4",
+			files: []github.PullRequestFile{
+				{Name: "server-access/get-started.mdx"},
+				{Name: "database-access/get-started.mdx"},
+			},
+			reviewers: []string{"2", "3"},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
@@ -1011,6 +1029,24 @@ func TestCheckInternal(t *testing.T) {
 			release: false,
 			large:   false,
 			result:  true,
+		},
+		{
+			desc:       "docs-with-non-preferred-code-reviewer",
+			repository: "teleport",
+			author:     "1",
+			reviews: []github.Review{
+				{Author: "3", State: Approved},
+			},
+			files: []github.PullRequestFile{
+				{
+					Name: "docs/pages/server-access/get-started.mdx",
+				},
+			},
+			docs:    true,
+			code:    false,
+			release: false,
+			large:   false,
+			result:  false,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
The code reviewer configuration allows us to name preferred reviewers for certain file paths. For docs PRs, the workflow bot does not consult the preferred reviewer configuration. This means that, even if we add the `preferredReviewerFor` key to a `codeReviewers` entry with a docs path as a value, the workflow bot continues to add only `docsReviewers` to docs PRs.

In this change, the workflow bot gets docs reviewers by:

1. Retrieving the docs reviewer pool from the config (like it does now).
1. Retrieving all preferred reviewers for the file paths included within a PR. Since the pool of dedicated docs reviewers is small, the workflow bot gets all preferred reviewers for a file path, not just one.
1. Merging the two lists of reviewers.

The alternative would be to allow preferred file paths in the docs reviewer pool, but it makes sense to have a small, consistent set of docs reviewers who have experience with docs reviews and a larger pool of subject matter experts for specific file paths from the code reviewer pool.

Implementation notes:

- Adds an `*Assignments.getAllPreferredReviewers` method, which fetches all preferred reviewers for all files in a change set, rather than limiting the number of reviewers per file to 1 as in `getPreferredReviewers`. This is necessary for `CheckInternal` to check that code reviewers with expertise over specific docs paths are counted as valid docs reviewers.
- Changes `getDocsReviewers`, `CheckInternal`, and `checkInternalDocsReviews` to take a slice of `PullRequestFile`s so they can apply the `getPreferredReviewers` logic.