### PR TITLE
Skip Dependency Review action in merge queue

### DIFF
--- a/.github/workflows/dependency-review-merge-queue.yaml
+++ b/.github/workflows/dependency-review-merge-queue.yaml
@@ -1,0 +1,25 @@
+# This check runs only on PRs that are in the merge queue.
+#
+# PRs in the merge queue have already been approved, but the dependency check
+# is still required, so this workflow allows the required check to succeed,
+# otherwise PRs in the merge queue would be blocked indefinitely.
+#
+# See "Handling skipped but required checks" for more info:
+#
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+#
+# Note both workflows must have the same name.
+name: 'Dependency Review'
+on:
+  merge_group:
+
+jobs:
+  dependency-review:
+    name: 'Dependency Review'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: none
+
+    steps:
+      - run: 'echo "Skipping dependency review in merge queue"'


### PR DESCRIPTION
Various attempts to skip the action were tried in `teleport.e`, but they all resulted in the Dependency Review check never reporting a status. This blocked all PRs from landing until the merge queue was disabled. By defining the skip here instead of in an upstream repo it should prevent the aforementioned issue.