### PR TITLE
Improvements to `dependency-review` action

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -14,6 +14,11 @@ on:
       - main
   workflow_call:
     inputs:
+      fail-on-severity:
+        description: "Minimum severity for failing PRs. Passed through to dependency-review-action"
+        default: "low"
+        required: false
+        type: string
       allow-ghsas:
         description: "Allowed GHSAs. Passed through to dependency-review-action"
         default: ""
@@ -21,6 +26,16 @@ on:
         type: string
       allow-dependencies-licenses:
         description: "Allowed dependency licenses. Passed through to dependency-review-action"
+        default: ""
+        required: false
+        type: string
+      base-ref:
+        description: "Base ref. Passed through to dependency-review-action"
+        default: ""
+        required: false
+        type: string
+      head-ref:
+        description: "Head ref. Passed through to dependency-review-action"
         default: ""
         required: false
         type: string
@@ -40,7 +55,9 @@ jobs:
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
         with:
-          fail-on-severity: moderate
+          fail-on-severity: ${{ inputs.fail-on-severity }}
           allow-licenses: 0BSD, Apache-2.0, BlueOak-1.0.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MIT-0, MPL-2.0, ODC-By-1.0, OFL-1.1, Python-2.0, Unicode-DFS-2016, Unlicense, WTFPL, Zlib, (MIT OR Apache-2.0) AND Unicode-DFS-2016, Apache-2.0 AND BSD-3-Clause, ISC AND MIT, MIT AND Zlib, MIT AND BSD-3-Clause, MIT AND WTFPL
           allow-ghsas: ${{ inputs.allow-ghsas }}
           allow-dependencies-licenses: ${{ inputs.allow-dependencies-licenses }}
+          base-ref: ${{ inputs.base-ref || github.event.pull_request.base.sha || 'main' }}
+          head-ref: ${{ inputs.head-ref || github.event.pull_request.head.sha || github.ref }}


### PR DESCRIPTION
* Support passing more variables as inputs
* Lower threshold before blocking to `low` severity
* Add default `base-ref` and `head-ref` to fix merge queue issues