### PR TITLE
 Add verification of DB migrations for access-graph 

### DIFF
--- a/bot/internal/bot/verify.go
+++ b/bot/internal/bot/verify.go
@@ -91,7 +91,7 @@ func (b *Bot) verifyDBMigration(ctx context.Context, pathPrefix string) error {
 
 	// no PR migration files
 	if len(prIDs) == 0 {
-		log.Print("Verify:cloudDBMigration: no migration files in this PR")
+		log.Printf("Verify:cloudDBMigration: no migration files in %s in this PR", pathPrefix)
 		return nil
 	}
 
@@ -146,7 +146,7 @@ func (b *Bot) verifyDBMigration(ctx context.Context, pathPrefix string) error {
 // the prefix ID of each file or returns an error if the file does not have an
 // integer prefix. The returned IDs are sorted in ascending order.
 //
-//	  202301031500_subscription-alter.up.sql => 202301031500
+//	202301031500_subscription-alter.up.sql => 202301031500
 func parseMigrationFileIDs(pathPrefix string, files []string) ([]int, error) {
 	var ids []int
 	for _, file := range files {

--- a/bot/internal/env/env.go
+++ b/bot/internal/env/env.go
@@ -27,9 +27,10 @@ import (
 
 const (
 	// Repo slugs
-	CloudRepo     = "cloud"
-	TeleportRepo  = "teleport"
-	TeleportERepo = "teleport.e"
+	AccessGraphRepo = "access-graph"
+	CloudRepo       = "cloud"
+	TeleportRepo    = "teleport"
+	TeleportERepo   = "teleport.e"
 
 	// Teams
 	CoreTeam     = "Core"

--- a/bot/main.go
+++ b/bot/main.go
@@ -137,7 +137,7 @@ func parseFlags() (flags, error) {
 	if *token == "" {
 		return flags{}, trace.BadParameter("token missing")
 	}
-	if *reviewers == "" && !*local {
+	if *reviewers == "" && !*local && (*workflow == "assign" || *workflow == "check") {
 		return flags{}, trace.BadParameter("reviewers required for assign and check")
 	}
 

--- a/bot/main.go
+++ b/bot/main.go
@@ -36,7 +36,7 @@ import (
 func main() {
 	flags, err := parseFlags()
 	if err != nil {
-		log.Fatalf("Failed to parse flags: %v.", err)
+		log.Fatalf("Failed to parse flags: %#v.", err)
 	}
 
 	// Cancel run if it takes longer than 5 minutes.
@@ -48,7 +48,7 @@ func main() {
 
 	b, err := createBot(ctx, flags)
 	if err != nil {
-		log.Fatalf("Failed to create bot: %v.", err)
+		log.Fatalf("Failed to create bot: %#v.", err)
 	}
 
 	log.Printf("Running %v.", flags.workflow)

--- a/bot/main.go
+++ b/bot/main.go
@@ -178,12 +178,9 @@ func createBot(ctx context.Context, flags flags) (*bot.Bot, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var reviewer *review.Assignments
-	if flags.workflow == "assign" || flags.workflow == "check" {
-		reviewer, err = review.FromString(flags.reviewers)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+	reviewer, err := review.FromString(flags.reviewers)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	b, err := bot.New(&bot.Config{
 		GitHub:      gh,

--- a/bot/main.go
+++ b/bot/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	b, err := createBot(ctx, flags)
 	if err != nil {
-		log.Fatalf("Failed to create bot: %#v.", err)
+		log.Fatalf("Failed to create bot: %v.", err)
 	}
 
 	log.Printf("Running %v.", flags.workflow)
@@ -137,7 +137,7 @@ func parseFlags() (flags, error) {
 	if *token == "" {
 		return flags{}, trace.BadParameter("token missing")
 	}
-	if *reviewers == "" && !*local && (*workflow == "assign" || *workflow == "check") {
+	if *reviewers == "" && !*local {
 		return flags{}, trace.BadParameter("reviewers required for assign and check")
 	}
 

--- a/bot/main.go
+++ b/bot/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	b, err := createBot(ctx, flags)
 	if err != nil {
-		log.Fatalf("Failed to create bot: %v.", err)
+		log.Fatalf("Failed to create bot: %#v.", err)
 	}
 
 	log.Printf("Running %v.", flags.workflow)

--- a/bot/main.go
+++ b/bot/main.go
@@ -178,9 +178,12 @@ func createBot(ctx context.Context, flags flags) (*bot.Bot, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	reviewer, err := review.FromString(flags.reviewers)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	var reviewer *review.Assignments
+	if flags.workflow == "assign" || flags.workflow == "check" {
+		reviewer, err = review.FromString(flags.reviewers)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	b, err := bot.New(&bot.Config{
 		GitHub:      gh,


### PR DESCRIPTION
Corresponding CI changes in `access-graph`: https://github.com/gravitational/shared-workflows/pull/185 (WIP)

* Adds ability to check for DB migration errors in the `access-graph` repo
* Makes `reviewers` parameter optional when not running `assign` or `check` workflows
* Improves logging, including a stack trace when the workflow exits with an error