### PR TITLE
`dependency-review`: Enable adding a comment in PR on failure

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -59,5 +59,6 @@ jobs:
           allow-licenses: 0BSD, Apache-2.0, BlueOak-1.0.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MIT-0, MPL-2.0, ODC-By-1.0, OFL-1.1, Python-2.0, Unicode-DFS-2016, Unlicense, WTFPL, Zlib, (MIT OR Apache-2.0) AND Unicode-DFS-2016, Apache-2.0 AND BSD-3-Clause, ISC AND MIT, MIT AND Zlib, MIT AND BSD-3-Clause, MIT AND WTFPL
           allow-ghsas: ${{ inputs.allow-ghsas }}
           allow-dependencies-licenses: ${{ inputs.allow-dependencies-licenses }}
+          comment-summary-in-pr: on-failure
           base-ref: ${{ inputs.base-ref || github.event.pull_request.base.sha || github.event.repository.default_branch }}
           head-ref: ${{ inputs.head-ref || github.event.pull_request.head.sha || github.ref }}


### PR DESCRIPTION
To make failures from `dependency-review` more noticeable and actionable, enabling adding a comment in the PR on a failure state.

Should be backwards-compatible even if the calling action doesn't have `pull-requests` write permission.