### PR TITLE
Add GitHub Action to lint incoming GitHub Actions

### DIFF
--- a/.github/workflows/github-action-lint.yaml
+++ b/.github/workflows/github-action-lint.yaml
@@ -1,0 +1,37 @@
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_call:
+
+name: Lint (GitHub Actions)
+
+jobs:
+  check-github-actions:
+    name: Check GitHub Actions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for affected paths
+        id: changes
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        with:
+          filters: |
+            github-actions:
+              - '.github/*/**/*.{yaml,yml}'
+
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@b35f285b9bb7e80de0967367cee66d3b6d50ceca # v3.0.1
+        if: steps.changes.outputs.github-actions == 'true'
+        with:
+          allowlist: |
+            github/
+            actions/
+            gravitational/shared-workflows/.github/workflows
+            gravitational/teleport/.github/workflows
+            gravitational/teleport.e/.github/workflows


### PR DESCRIPTION
This workflow will check that all changed and added GitHub actions are either pinned to a hash, or on an allow list. This workflow is built to be reusable across Teleport repos, in addition to enforcing standards in this repo.

I chose to add it here to benefit from shared `dorny/paths-filter` logic as well as a common allow list of "safe actions".

Contributes to https://github.com/gravitational/security-findings/issues/50

## Testing

I tested [a version of this workflow](https://github.com/wadells/gha-test/blob/acfbd373971851fb2d0d071beb6cc28feb50ded5/.github/workflows/lint-github-actions.yml) in [wadells/gha-test](https://github.com/wadells/gha-test).  Check out the follow pull request to see it in action:

https://github.com/wadells/gha-test/pull/3

I'll do further testing as we roll this out to different repos.  This merge will only affect this repo for the time being.

## Notes

`teleport` and `teleport.e` are already compliant with this lint config for all supported branches.  I plan to add this to all Production-Internal and Production-Public repos (as defined in [the GitHub Enterprise RFD](https://gravitational.slab.com/posts/rfd-github-enterprise-o1d3c7t2#hcffh-attribute-matrix-for-repo-type)).  For repos that aren't yet compliant (such as `shared-workflows`) I'll make sure to fix master before rollout.

`zgosalvez/github-actions-ensure-sha-pinned-actions` is currently [broken](https://github.com/zgosalvez/github-actions-ensure-sha-pinned-actions/issues/133) (it allows stuff through that it shouldn't).  I've got a PR out to fix it:

https://github.com/zgosalvez/github-actions-ensure-sha-pinned-actions/pull/132