### PR TITLE
Replace tj-actions/changed-files with dorny/paths-filter

### DIFF
--- a/.github/workflows/csv-lint.yaml
+++ b/.github/workflows/csv-lint.yaml
@@ -18,11 +18,12 @@ jobs:
           fetch-depth: 2
 
       - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v40.2.0
+        id: filter
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         with:
-          files: |
-            **/*.csv
+          filters: |
+            csv:
+              - '**/*.csv'
 
       - name: Setup Go
         uses: actions/setup-go@v4
@@ -36,10 +37,10 @@ jobs:
           path: csvlint
 
       - name: csvlint
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.filter.outputs.csv == 'true'
         run: |
           cd csvlint
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          for file in ${{ steps.filter.outputs.csv_files }}; do
             echo "Validating ${file}"
             go run cmd/csvlint/main.go ../${file}
           done

--- a/.github/workflows/json-lint.yaml
+++ b/.github/workflows/json-lint.yaml
@@ -18,16 +18,17 @@ jobs:
           fetch-depth: 2
 
       - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v40.2.0
+        id: filter
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         with:
-          files: |
-            **/*.json
+          filters: |
+            json:
+              - '**/*.json'
 
       - name: jsonlint
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.filter.outputs.json == 'true'
         run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          for file in ${{ steps.filter.outputs.json_files }}; do
             echo "Validating ${file}"
             jq empty ${file}
           done


### PR DESCRIPTION
These actions both perform the same function.  However dorny/paths-filter has higher usage within the Teleport organization, and it is better to have one dependency to track/keep up to date instead of two.