### PR TITLE
Pin terraform lint GitHub Actions

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
 
       - name: terraform fmt
         run: terraform fmt -no-color -check -diff -recursive
@@ -39,7 +39,7 @@ jobs:
           key: tflint-${{ hashFiles('.tflint.hcl') }}
 
       - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v4
+        uses: terraform-linters/setup-tflint@19a52fbac37dacb22a09518e4ef6ee234f2d4987 # v4.0.0
 
       - name: Show version
         run: tflint --version


### PR DESCRIPTION
We prefer to pin all GitHub Actions from a 3rd party in order to increase determinism and security for our workflows.

Contributes to https://github.com/gravitational/security-findings/issues/50

This should be merged before https://github.com/gravitational/shared-workflows/pull/188.