### PR TITLE
Revert "Replace tj-actions/changed-files with dorny/paths-filter"

### DIFF
--- a/.github/workflows/csv-lint.yaml
+++ b/.github/workflows/csv-lint.yaml
@@ -18,12 +18,11 @@ jobs:
           fetch-depth: 2
 
       - name: Get changed files
-        id: filter
-        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: changed-files
+        uses: tj-actions/changed-files@v40.2.0
         with:
-          filters: |
-            csv:
-              - '**/*.csv'
+          files: |
+            **/*.csv
 
       - name: Setup Go
         uses: actions/setup-go@v4
@@ -37,10 +36,10 @@ jobs:
           path: csvlint
 
       - name: csvlint
-        if: steps.filter.outputs.csv == 'true'
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           cd csvlint
-          for file in ${{ steps.filter.outputs.csv_files }}; do
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             echo "Validating ${file}"
             go run cmd/csvlint/main.go ../${file}
           done

--- a/.github/workflows/json-lint.yaml
+++ b/.github/workflows/json-lint.yaml
@@ -18,17 +18,16 @@ jobs:
           fetch-depth: 2
 
       - name: Get changed files
-        id: filter
-        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: changed-files
+        uses: tj-actions/changed-files@v40.2.0
         with:
-          filters: |
-            json:
-              - '**/*.json'
+          files: |
+            **/*.json
 
       - name: jsonlint
-        if: steps.filter.outputs.json == 'true'
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          for file in ${{ steps.filter.outputs.json_files }}; do
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             echo "Validating ${file}"
             jq empty ${file}
           done


### PR DESCRIPTION
Reverts gravitational/shared-workflows#189.

Callers need additional permissions (`read: pull-request`) or they'll fail with the following signature:

https://github.com/gravitational/cloud-terraform/actions/runs/7091297245/job/19300146222?pr=3784

```
Fetching list of changed files for PR#3784 from Github API
  Invoking listFiles(pull_number: 3784, per_page: 100)
Error: Resource not accessible by integration
```

Rolling back for now.  I'll look at updating call sites and then rolling back forward.

This is because `dorny/paths-filter` uses the github api to read diffs instead of `tj-actions` using the git history of the local checkout.  At least that is what my initial research suggests.