### PR TITLE
Fixed `dependency-review` check failing on Teleport API

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -58,7 +58,7 @@ jobs:
           fail-on-severity: ${{ inputs.fail-on-severity }}
           allow-licenses: 0BSD, Apache-2.0, BlueOak-1.0.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MIT-0, MPL-2.0, ODC-By-1.0, OFL-1.1, Python-2.0, Unicode-DFS-2016, Unlicense, WTFPL, Zlib, (MIT OR Apache-2.0) AND Unicode-DFS-2016, Apache-2.0 AND BSD-3-Clause, ISC AND MIT, MIT AND Zlib, MIT AND BSD-3-Clause, MIT AND WTFPL
           allow-ghsas: ${{ inputs.allow-ghsas }}
-          allow-dependencies-licenses: ${{ inputs.allow-dependencies-licenses }}
+          allow-dependencies-licenses: ${{ inputs.allow-dependencies-licenses != '' && format('pkg:golang/github.com/gravitational/teleport/api, {0}', inputs.allow-dependencies-licenses) || 'pkg:golang/github.com/gravitational/teleport/api'}}
           comment-summary-in-pr: on-failure
           base-ref: ${{ inputs.base-ref || github.event.pull_request.base.sha || github.event.repository.default_branch }}
           head-ref: ${{ inputs.head-ref || github.event.pull_request.head.sha || github.ref }}


### PR DESCRIPTION
This check does not support repositories with multiple licenses due to the way the license query logic is implemented upstream. This PR adds an exception for the Teleport API package, which will affect all repos using this artifact.

This syntax is not very pretty, but this is the most simple solution that I could come up with due to GHA expression weirdness.

Tested via https://github.com/gravitational/cloud/pull/6901