### PR TITLE
Automatically copy changelog message to the backport or put no-changelog label

### DIFF
--- a/bot/internal/bot/backport_test.go
+++ b/bot/internal/bot/backport_test.go
@@ -17,9 +17,14 @@ limitations under the License.
 package bot
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/shared-workflows/bot/internal/env"
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+	"github.com/gravitational/shared-workflows/bot/internal/review"
 )
 
 func TestFindBranches(t *testing.T) {
@@ -34,4 +39,112 @@ func TestFindBranches(t *testing.T) {
 		"branch/v7",
 		"master",
 	})
+}
+
+func TestBackport(t *testing.T) {
+	buildTestBot := func(github Client) (*Bot, context.Context) {
+		r, _ := review.New(&review.Config{
+			CodeReviewers: map[string]review.Reviewer{"dev": review.Reviewer{
+				Team: "core",
+			}},
+			CodeReviewersOmit: map[string]bool{},
+			DocsReviewers:     map[string]review.Reviewer{},
+			DocsReviewersOmit: map[string]bool{},
+			Admins:            []string{},
+		})
+
+		return &Bot{
+			c: &Config{
+				Environment: &env.Environment{
+					Organization: "foo",
+					Author:       "dev",
+					Repository:   "bar",
+					Number:       42,
+					UnsafeBase:   "branch/v8",
+					UnsafeHead:   "fix",
+				},
+				GitHub: github,
+				Review: r,
+				Git:    gitDryRun,
+			},
+		}, context.Background()
+	}
+
+	tests := []struct {
+		desc       string
+		github     Client
+		assertFunc require.ValueAssertionFunc
+	}{
+		{
+			desc:       "pr without backport labels",
+			github:     &fakeGithub{},
+			assertFunc: require.Empty,
+		},
+		{
+			desc: "pr with backport label, no changelog",
+			github: &fakeGithub{
+				pull: github.PullRequest{
+					Author:       "dev",
+					Repository:   "Teleport",
+					Number:       42,
+					UnsafeTitle:  "Best PR",
+					UnsafeBody:   "This is PR body",
+					UnsafeLabels: []string{"backport/branch/v7"},
+				},
+				jobs: []github.Job{{Name: "Job1", ID: 1}},
+			},
+			assertFunc: func(t require.TestingT, i interface{}, i2 ...interface{}) {
+				comments, ok := i.([]github.Comment)
+				require.True(t, ok)
+				require.Len(t, comments, 1)
+				require.Equal(t,
+					`
+@dev See the table below for backport results.
+
+| Branch | Result |
+|--------|--------|
+| branch/v7 | [Create PR](https://github.com/foo/bar/compare/branch/v7...bot/backport-42-branch/v7?body=Backport+%2342+to+branch%2Fv7&expand=1&labels=no-changelog&title=%5Bv7%5D+Best+PR) |
+`, comments[0].Body)
+			},
+		},
+		{
+			desc: "pr with backport label and with changelog",
+			github: &fakeGithub{
+				pull: github.PullRequest{
+					Author:       "dev",
+					Repository:   "Teleport",
+					Number:       42,
+					UnsafeTitle:  "Best PR",
+					UnsafeBody:   "This is PR body\n\nchangelog: important change",
+					UnsafeLabels: []string{"backport/branch/v7"},
+				},
+				jobs: []github.Job{{Name: "Job1", ID: 1}},
+			},
+			assertFunc: func(t require.TestingT, i interface{}, i2 ...interface{}) {
+				comments, ok := i.([]github.Comment)
+				require.True(t, ok)
+				require.Len(t, comments, 1)
+				require.Equal(t,
+					`
+@dev See the table below for backport results.
+
+| Branch | Result |
+|--------|--------|
+| branch/v7 | [Create PR](https://github.com/foo/bar/compare/branch/v7...bot/backport-42-branch/v7?body=Backport+%2342+to+branch%2Fv7%0A%0Achangelog%3A+important+change%0A&expand=1&title=%5Bv7%5D+Best+PR) |
+`, comments[0].Body)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			b, ctx := buildTestBot(test.github)
+
+			err := b.Backport(ctx)
+			require.NoError(t, err)
+
+			comments, _ := b.c.GitHub.ListComments(nil, "", "", 0)
+			test.assertFunc(t, comments)
+		})
+	}
 }

--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"strings"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/shared-workflows/bot/internal/env"
 	"github.com/gravitational/shared-workflows/bot/internal/github"
 	"github.com/gravitational/shared-workflows/bot/internal/review"
-
-	"github.com/gravitational/trace"
 )
 
 // Client implements the GitHub API.
@@ -44,7 +44,7 @@ type Client interface {
 	// GetPullRequest returns a specific Pull Request.
 	GetPullRequest(ctx context.Context, organization string, repository string, number int) (github.PullRequest, error)
 
-	// GetPullRequestWithCommitsd returns a specific Pull Request with commits.
+	// GetPullRequestWithCommits returns a specific Pull Request with commits.
 	GetPullRequestWithCommits(ctx context.Context, organization string, repository string, number int) (github.PullRequest, error)
 
 	// CreatePullRequest will create a Pull Request.
@@ -97,6 +97,9 @@ type Config struct {
 
 	// Review is used to get code and docs reviewers.
 	Review *review.Assignments
+
+	// Git is used to run git commands, uses dry run in tests.
+	Git func(...string) error
 }
 
 // CheckAndSetDefaults checks and sets defaults.

--- a/bot/internal/bot/bot_test.go
+++ b/bot/internal/bot/bot_test.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/shared-workflows/bot/internal/env"
 	"github.com/gravitational/shared-workflows/bot/internal/github"
 	"github.com/gravitational/shared-workflows/bot/internal/review"
-
-	"github.com/stretchr/testify/require"
 )
 
 // TestClassifyChanges checks that PR contents are correctly parsed for docs and
@@ -311,6 +311,7 @@ func TestDoNotMerge(t *testing.T) {
 type fakeGithub struct {
 	files       []github.PullRequestFile
 	pull        github.PullRequest
+	jobs        []github.Job
 	reviewers   []string
 	reviews     []github.Review
 	orgMembers  map[string]struct{}
@@ -364,7 +365,7 @@ func (f *fakeGithub) ListWorkflowRuns(ctx context.Context, organization string, 
 }
 
 func (f *fakeGithub) ListWorkflowJobs(ctx context.Context, organization string, repository string, runID int64) ([]github.Job, error) {
-	return nil, nil
+	return f.jobs, nil
 }
 
 func (f *fakeGithub) DeleteWorkflowRun(ctx context.Context, organization string, repository string, runID int64) error {
@@ -377,6 +378,10 @@ func (f *fakeGithub) IsOrgMember(ctx context.Context, user string, org string) (
 }
 
 func (f *fakeGithub) CreateComment(ctx context.Context, organization string, repository string, number int, comment string) error {
+	f.comments = append(f.comments, github.Comment{
+		Body: comment,
+	})
+
 	return nil
 }
 

--- a/bot/internal/bot/changelog_test.go
+++ b/bot/internal/bot/changelog_test.go
@@ -23,9 +23,10 @@ import (
 	"testing"
 	"unicode"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/shared-workflows/bot/internal/env"
 	"github.com/gravitational/shared-workflows/bot/internal/github"
-	"github.com/stretchr/testify/require"
 )
 
 func TestChangelog(t *testing.T) {
@@ -40,34 +41,29 @@ func TestChangelog(t *testing.T) {
 
 func TestGetChangelogEntry(t *testing.T) {
 	tests := []struct {
-		desc        string
-		body        string
-		shouldError bool
-		expected    []string
+		desc     string
+		body     string
+		expected []string
 	}{
 		{
-			desc:        "pass-simple",
-			body:        strings.Join([]string{"some typical PR entry", fmt.Sprintf("%schangelog entry", ChangelogPrefix), "some extra text"}, "\n"),
-			shouldError: false,
-			expected:    []string{"changelog entry"},
+			desc:     "pass-simple",
+			body:     strings.Join([]string{"some typical PR entry", fmt.Sprintf("%schangelog entry", ChangelogPrefix), "some extra text"}, "\n"),
+			expected: []string{"changelog entry"},
 		},
 		{
-			desc:        "pass-case-invariant",
-			body:        strings.Join([]string{"some typical PR entry", fmt.Sprintf("%schangelog entry", strings.ToUpper(ChangelogPrefix))}, "\n"),
-			shouldError: false,
-			expected:    []string{"changelog entry"},
+			desc:     "pass-case-invariant",
+			body:     strings.Join([]string{"some typical PR entry", fmt.Sprintf("%schangelog entry", strings.ToUpper(ChangelogPrefix))}, "\n"),
+			expected: []string{"changelog entry"},
 		},
 		{
-			desc:        "pass-prefix-in-changelog-entry",
-			body:        strings.Join([]string{"some typical PR entry", strings.Repeat(ChangelogPrefix, 5)}, "\n"),
-			shouldError: false,
-			expected:    []string{strings.Repeat(ChangelogPrefix, 4)},
+			desc:     "pass-prefix-in-changelog-entry",
+			body:     strings.Join([]string{"some typical PR entry", strings.Repeat(ChangelogPrefix, 5)}, "\n"),
+			expected: []string{strings.Repeat(ChangelogPrefix, 4)},
 		},
 		{
-			desc:        "pass-only-changelog-in-body",
-			body:        fmt.Sprintf("%schangelog entry", ChangelogPrefix),
-			shouldError: false,
-			expected:    []string{"changelog entry"},
+			desc:     "pass-only-changelog-in-body",
+			body:     fmt.Sprintf("%schangelog entry", ChangelogPrefix),
+			expected: []string{"changelog entry"},
 		},
 		{
 			desc: "pass-multiple-entries",
@@ -81,28 +77,24 @@ func TestGetChangelogEntry(t *testing.T) {
 				"entry 2",
 				"entry 3",
 			},
-			shouldError: false,
 		},
 		{
-			desc:        "fail-if-no-body",
-			body:        "",
-			shouldError: true,
+			desc:     "empty-if-no-body",
+			body:     "",
+			expected: nil,
 		},
 		{
-			desc:        "fail-if-no-entry",
-			body:        "some typical PR entry",
-			shouldError: true,
+			desc:     "empty-if-no-entry",
+			body:     "some typical PR entry",
+			expected: nil,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			b, ctx := buildTestingFixtures()
+			b, _ := buildTestingFixtures()
 
-			changelogEntries, err := b.getChangelogEntries(ctx, test.body)
-			require.Equal(t, test.shouldError, err != nil)
-			if !test.shouldError {
-				require.Exactly(t, test.expected, changelogEntries)
-			}
+			changelogEntries := b.getChangelogEntries(test.body)
+			require.Exactly(t, test.expected, changelogEntries)
 		})
 	}
 }


### PR DESCRIPTION
With the new requirement of specifying changelog in the PR body or no-changelog label there's a problem with automatic backports, since they automatically fail those requirements. This PR improves backporting procedure by copying changelog message from the parent PR if it's present, or setting no-changelog label.