### PR TITLE
csv-lint & json-lint: Use `printf %q` to sanatize input and avoid command injection

### DIFF
--- a/.github/workflows/csv-lint.yaml
+++ b/.github/workflows/csv-lint.yaml
@@ -40,6 +40,7 @@ jobs:
         run: |
           cd csvlint
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo "Validating ${file}"
-            go run cmd/csvlint/main.go ../${file}
+            sanitized_file=$(printf '%q' "$file")
+            echo "Validating ${sanitized_file}"
+            go run cmd/csvlint/main.go ../${sanitized_file}
           done

--- a/.github/workflows/json-lint.yaml
+++ b/.github/workflows/json-lint.yaml
@@ -28,6 +28,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo "Validating ${file}"
-            jq empty ${file}
+            sanitized_file=$(printf '%q' "$file")
+            echo "Validating ${sanitized_file}"
+            jq empty ${sanitized_file}
           done


### PR DESCRIPTION
`printf %q` is a useful feature whenever we need to provide the input into a shell command.  It will escape characters which could be used for injection.

This PR fixes https://github.com/gravitational/security-findings/issues/52