### PR TITLE
verify: Exclude down migration files

### DIFF
--- a/bot/internal/bot/verify.go
+++ b/bot/internal/bot/verify.go
@@ -84,7 +84,7 @@ func (b *Bot) verifyDBMigration(ctx context.Context, pathPrefix string) error {
 
 	// parse PR migration file ids
 	// 202301031500_subscription-alter.up.sql => 202301031500
-	prIDs, err := parseMigrationFileIDs(pathPrefix, pullRequestFileNames(prFiles))
+	prIDs, err := parseMigrationFileIDs(pathPrefix, excludeDownMigrationFiles(pullRequestFileNames(prFiles)))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -185,6 +185,18 @@ func parseMigrationFileID(file string) (int, error) {
 	}
 
 	return id, nil
+}
+
+// excludeDownMigrationFiles returns the same list of names
+// excluding files whose suffix is '.down.sql'.
+func excludeDownMigrationFiles(names []string) []string {
+	filtered := make([]string, 0, len(names))
+	for _, n := range names {
+		if !strings.HasSuffix(n, ".down.sql") {
+			filtered = append(filtered, n)
+		}
+	}
+	return filtered
 }
 
 // pullRequestFileNames returns all Name fields from each PullRequestFile.

--- a/bot/internal/bot/verify_test.go
+++ b/bot/internal/bot/verify_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gravitational/shared-workflows/bot/internal/env"
 	"github.com/gravitational/shared-workflows/bot/internal/github"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseMigrationFileID(t *testing.T) {
@@ -157,6 +158,16 @@ func TestVerifyCloudDBMigration(t *testing.T) {
 				"db/202301031501_exists.up.sql",
 			},
 		},
+		{ // 6 OK extra down file
+			prFiles: []string{
+				"db/202301031501_adding.up.sql",
+				"db/202301031501_adding.down.sql",
+				"db/202109104352_exclude.down.sql",
+			},
+			branchFiles: []string{
+				"db/202301031500_exists.up.sql",
+			},
+		},
 	}
 	fghBaseline := *fgh
 	for i, test := range cases {
@@ -183,5 +194,21 @@ func TestVerifyCloudDBMigration(t *testing.T) {
 		}
 
 		*fgh = fghBaseline
+	}
+}
+
+func TestFilterDownMigrationFiles(t *testing.T) {
+	cases := []struct {
+		names  []string
+		expect []string
+	}{
+		{
+			names:  []string{"foo", "bar.up.sql", "bar.down.sql"},
+			expect: []string{"foo", "bar.up.sql"},
+		},
+	}
+	for _, test := range cases {
+		got := excludeDownMigrationFiles(test.names)
+		require.Equal(t, test.expect, got)
 	}
 }


### PR DESCRIPTION
Exclude down migration files from the verify check. Only the up files are applied during deployment and some [recent PRs](https://github.com/gravitational/cloud/pull/7074) modified an old down migration file which [prevented the verify workflow from succeeding](https://github.com/gravitational/cloud/actions/runs/7278259607/job/19832056114). 