### PR TITLE
bot: Single Approval Paths

### DIFF
--- a/bot/internal/bot/assign.go
+++ b/bot/internal/bot/assign.go
@@ -72,7 +72,7 @@ func (b *Bot) getReviewers(ctx context.Context, files []github.PullRequestFile) 
 		log.Printf("Assign: Found backport PR, but failed to find original reviewers: %v. Falling through to normal assignment logic.", err)
 	}
 
-	changes := classifyChanges(b.c.Environment, files)
+	changes := classifyChanges(b.c, files)
 	return b.c.Review.Get(b.c.Environment, changes, files), nil
 }
 

--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -180,14 +180,9 @@ func approverCount(authors, paths []string, author string, files []github.PullRe
 		return env.DefaultApproverCount
 	}
 	for _, file := range files {
-		var match bool
-		for _, path := range paths {
-			if strings.HasPrefix(file.Name, path) {
-				match = true
-				break
-			}
-		}
-		if !match {
+		if !slices.ContainsFunc(paths, func(path string) bool {
+			return strings.HasPrefix(file.Name, path)
+		}) {
 			return env.DefaultApproverCount
 		}
 	}

--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/gravitational/trace"
+	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/shared-workflows/bot/internal/env"
 	"github.com/gravitational/shared-workflows/bot/internal/github"
@@ -170,10 +171,8 @@ func approverCount(authors, paths []string, author string, files []github.PullRe
 	}
 
 	// check if pr author only requires a single approval
-	for _, a := range authors {
-		if author == a {
-			return 1
-		}
+	if slices.Contains(authors, author) {
+		return 1
 	}
 
 	// check if pr files only require a single approval

--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -136,7 +136,7 @@ func classifyChanges(c *Config, files []github.PullRequestFile) env.Changes {
 	ch := env.Changes{
 		Large:         !c.Environment.IsCloudDeployBranch() && xlargeRequiresAdminApproval(files),
 		Release:       isReleasePR(c.Environment, files),
-		ApproverCount: approverCount(c.Review.SingleApproverPaths(c.Environment.Repository), files),
+		ApproverCount: approverCount(review.SingleApproverPaths(c.Environment.Repository), files),
 	}
 	switch c.Environment.Repository {
 	case env.TeleportRepo:

--- a/bot/internal/bot/bot_test.go
+++ b/bot/internal/bot/bot_test.go
@@ -310,10 +310,12 @@ func TestDoNotMerge(t *testing.T) {
 
 func TestApproverCount(t *testing.T) {
 	cases := []struct {
-		desc   string
-		paths  []string
-		files  []github.PullRequestFile
-		expect int
+		desc    string
+		author  string
+		authors []string
+		paths   []string
+		files   []github.PullRequestFile
+		expect  int
 	}{
 		{
 			desc:   "no paths or files",
@@ -367,10 +369,24 @@ func TestApproverCount(t *testing.T) {
 			paths:  []string{"lib/default", "lib/db"},
 			expect: 1,
 		},
+		{
+			desc:    "authors without match",
+			author:  "foo",
+			authors: []string{"bar"},
+			files:   []github.PullRequestFile{{Name: "cannot_be_zero"}},
+			expect:  env.DefaultApproverCount,
+		},
+		{
+			desc:    "authors with match",
+			author:  "foo",
+			authors: []string{"bar", "foo"},
+			files:   []github.PullRequestFile{{Name: "cannot_be_zero"}},
+			expect:  1,
+		},
 	}
 	for _, test := range cases {
 		t.Run(test.desc, func(t *testing.T) {
-			got := approverCount(test.paths, test.files)
+			got := approverCount(test.authors, test.paths, test.author, test.files)
 			require.Equal(t, test.expect, got)
 		})
 	}

--- a/bot/internal/bot/bot_test.go
+++ b/bot/internal/bot/bot_test.go
@@ -70,10 +70,10 @@ func TestClassifyChanges(t *testing.T) {
 			code:  false,
 		},
 	}
-	e := &env.Environment{Repository: env.TeleportRepo}
+	c := &Config{Environment: &env.Environment{Repository: env.TeleportRepo}}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			changes := classifyChanges(e, test.files)
+			changes := classifyChanges(c, test.files)
 			require.Equal(t, changes.Docs, test.docs)
 			require.Equal(t, changes.Code, test.code)
 		})
@@ -306,6 +306,74 @@ func TestDoNotMerge(t *testing.T) {
 		},
 	}
 	require.Error(t, bot.checkDoNotMerge(context.Background()))
+}
+
+func TestApproverCount(t *testing.T) {
+	cases := []struct {
+		desc   string
+		paths  []string
+		files  []github.PullRequestFile
+		expect int
+	}{
+		{
+			desc:   "no paths or files",
+			expect: env.DefaultApproverCount,
+		},
+		{
+			desc: "no paths",
+			files: []github.PullRequestFile{
+				{Name: "lib/default.go"},
+			},
+			expect: env.DefaultApproverCount,
+		},
+		{
+			desc:   "no files",
+			paths:  []string{"single/approver"},
+			expect: env.DefaultApproverCount,
+		},
+		{
+			desc: "no files matching paths",
+			files: []github.PullRequestFile{
+				{Name: "lib/default.go"},
+				{Name: "lib/db.go"},
+			},
+			paths:  []string{"single/approver"},
+			expect: env.DefaultApproverCount,
+		},
+		{
+			desc: "one file matching path",
+			files: []github.PullRequestFile{
+				{Name: "lib/default.go"},
+				{Name: "lib/db.go"},
+			},
+			paths:  []string{"lib/db.go"},
+			expect: env.DefaultApproverCount,
+		},
+		{
+			desc: "all files matching path",
+			files: []github.PullRequestFile{
+				{Name: "lib/default.go"},
+				{Name: "lib/db.go"},
+			},
+			paths:  []string{"lib"},
+			expect: 1,
+		},
+		{
+			desc: "all files matching multiple paths",
+			files: []github.PullRequestFile{
+				{Name: "lib/default.go"},
+				{Name: "lib/db.go"},
+			},
+			paths:  []string{"lib/default", "lib/db"},
+			expect: 1,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.desc, func(t *testing.T) {
+			got := approverCount(test.paths, test.files)
+			require.Equal(t, test.expect, got)
+		})
+	}
 }
 
 type fakeGithub struct {

--- a/bot/internal/bot/check.go
+++ b/bot/internal/bot/check.go
@@ -73,7 +73,7 @@ func (b *Bot) Check(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	changes := classifyChanges(b.c.Environment, files)
+	changes := classifyChanges(b.c, files)
 
 	if changes.Large {
 		comment := fmt.Sprintf("@%v - this PR will require admin approval to merge due to its size. "+

--- a/bot/internal/env/changes.go
+++ b/bot/internal/env/changes.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package env
 
+// DefaultApproverCount is the default number of required approvers.
+// This value should be greater than 1.
+const DefaultApproverCount = 2
+
 // Changes contains classification of the PR changes.
 type Changes struct {
 	// Code indicates the PR contains code changes.
@@ -26,4 +30,6 @@ type Changes struct {
 	Release bool
 	// Large indicates the PR changeset is large.
 	Large bool
+	// Number of required approvers (default is DefaultApproverCount)
+	ApproverCount int
 }

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -60,7 +60,7 @@ var (
 
 	// singleApproverAuthors defines pull request authors in cloud or core repos that only
 	// require a single approver. The map key is the repo (cloud|teleport|teleport.e) and the
-	// value is a list of authors.
+	// value is a list of authors. BOTS ONLY - DO NOT INCLUDE EMPLOYEE GITHUB HANDLES.
 	singleApproverAuthors = map[string][]string{
 		"cloud": []string{Dependabot, DependabotBatcher, RenovateBotPrivate, RenovateBotPublic},
 	}

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -49,6 +49,21 @@ const (
 	PostReleaseBot = "teleport-post-release-automation[bot]"
 )
 
+var (
+	// singleApproverPaths defines paths in cloud or core repos that only require a single approver.
+	// The map key is the repo (cloud|teleport|teleport.e) and the value is a list of paths.
+	singleApproverPaths = map[string][]string{
+		"cloud": []string{
+			"deploy/fluxcd/config/values.yaml",
+		},
+	}
+)
+
+// SingleApproverPaths returns repository paths that only require a single approver.
+func SingleApproverPaths(repository string) []string {
+	return singleApproverPaths[repository]
+}
+
 func isAllowedRobot(author string) bool {
 	switch author {
 	case Dependabot, DependabotBatcher, RenovateBotPrivate, RenovateBotPublic, PostReleaseBot:
@@ -94,10 +109,6 @@ type Config struct {
 
 	// Admins are assigned reviews when no others match.
 	Admins []string `json:"admins"`
-
-	// SingleApproverPaths defines paths in cloud or core repos that only require a single approver.
-	// The map key is the repo (cloud|teleport|teleport.e) and the value is a list of paths.
-	SingleApproverPaths map[string][]string
 }
 
 // CheckAndSetDefaults checks and sets defaults.
@@ -156,15 +167,6 @@ func New(c *Config) (*Assignments, error) {
 	return &Assignments{
 		c: c,
 	}, nil
-}
-
-// SingleApproverPaths returns the configured paths that only require a single
-// approval in a given repository as defined in the bot config file.
-func (r *Assignments) SingleApproverPaths(repo string) []string {
-	if r == nil {
-		return nil
-	}
-	return r.c.SingleApproverPaths[repo]
 }
 
 // IsInternal checks whether the author of a PR is explicitly

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -57,11 +57,23 @@ var (
 			"deploy/fluxcd/config/values.yaml",
 		},
 	}
+
+	// singleApproverAuthors defines pull request authors in cloud or core repos that only
+	// require a single approver. The map key is the repo (cloud|teleport|teleport.e) and the
+	// value is a list of authors.
+	singleApproverAuthors = map[string][]string{
+		"cloud": []string{Dependabot, DependabotBatcher, RenovateBotPrivate, RenovateBotPublic},
+	}
 )
 
 // SingleApproverPaths returns repository paths that only require a single approver.
 func SingleApproverPaths(repository string) []string {
 	return singleApproverPaths[repository]
+}
+
+// SingleApproverAuthors returns a list of authors that only require a single approver.
+func SingleApproverAuthors(repository string) []string {
+	return singleApproverAuthors[repository]
 }
 
 func isAllowedRobot(author string) bool {

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package review
 
 import (
+	"slices"
 	"sort"
 	"testing"
 
@@ -1189,6 +1190,21 @@ func TestPreferredReviewers(t *testing.T) {
 			sort.Strings(actual)
 			require.ElementsMatch(t, test.expected, actual)
 		})
+	}
+}
+
+func TestSingleApproverAuthors(t *testing.T) {
+	name := func(authors []string, i int) string {
+		if i == -1 {
+			return ""
+		}
+		return authors[i]
+	}
+	for repo, authors := range singleApproverAuthors {
+		i := slices.IndexFunc(authors, func(author string) bool {
+			return !isAllowedRobot(author)
+		})
+		require.Equal(t, -1, i, "%q is not allowed to be a single approver author in the %q repository (only bots)", name(authors, i), repo)
 	}
 }
 

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -403,7 +403,8 @@ func TestGetCodeReviewers(t *testing.T) {
 				Repository: test.repository,
 				Author:     test.author,
 			}
-			require.ErrorContains(t, test.assignments.checkInternalCodeReviews(e, nil),
+			changes := env.Changes{ApproverCount: env.DefaultApproverCount}
+			require.ErrorContains(t, test.assignments.checkInternalCodeReviews(e, changes, nil),
 				"at least one approval required from each set")
 
 			setA, setB := test.assignments.getCodeReviewerSets(e)
@@ -1056,10 +1057,11 @@ func TestCheckInternal(t *testing.T) {
 				Author:     test.author,
 			}
 			err := r.CheckInternal(e, test.reviews, env.Changes{
-				Docs:    test.docs,
-				Code:    test.code,
-				Large:   test.large,
-				Release: test.release,
+				Docs:          test.docs,
+				Code:          test.code,
+				Large:         test.large,
+				Release:       test.release,
+				ApproverCount: env.DefaultApproverCount,
 			}, test.files)
 			if test.result {
 				require.NoError(t, err)
@@ -1104,6 +1106,9 @@ func TestFromString(t *testing.T) {
 	require.EqualValues(t, r.c.Admins, []string{
 		"7",
 		"8",
+	})
+	require.EqualValues(t, r.c.SingleApproverPaths, map[string][]string{
+		"cloud": []string{"single/approval/path"},
 	})
 }
 
@@ -1221,6 +1226,11 @@ const reviewers = `
 	"admins": [
 		"7",
 		"8"
-	]
+	],
+	"singleApproverPaths": {
+		"cloud": [
+			"single/approval/path"
+		]
+	}
 }
 `

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -1107,9 +1107,6 @@ func TestFromString(t *testing.T) {
 		"7",
 		"8",
 	})
-	require.EqualValues(t, r.c.SingleApproverPaths, map[string][]string{
-		"cloud": []string{"single/approval/path"},
-	})
 }
 
 type randStatic struct{}
@@ -1226,11 +1223,6 @@ const reviewers = `
 	"admins": [
 		"7",
 		"8"
-	],
-	"singleApproverPaths": {
-		"cloud": [
-			"single/approval/path"
-		]
-	}
+	]
 }
 `


### PR DESCRIPTION
This PR addresses the "Single Approver" issue described in #205.

Add the ability for certain PRs to require a single approval. 

A new setting has been added, singleApproverPaths, that defines paths in a repository that only require a single approver. If all the files in a PR only match paths defined in singleApproverPaths, then the PR only requires a single approval. Otherwise, the PR requires the default number of approvals, which is currently defined as 2.

A second setting was added, singleApproverAuthors, that defines PR authors that only require a single approval (dependency bots in cloud for now).
