### PR TITLE
bot: Allow the same reviewer in both core and cloud repos

### DIFF
--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -18,10 +18,10 @@ package bot
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/gravitational/trace"
-	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/shared-workflows/bot/internal/env"
 	"github.com/gravitational/shared-workflows/bot/internal/github"

--- a/bot/internal/env/env.go
+++ b/bot/internal/env/env.go
@@ -132,6 +132,14 @@ func (e *Environment) IsCloudDeployBranch() bool {
 		(e.UnsafeBase == CloudProdBranch || e.UnsafeBase == CloudStagingBranch)
 }
 
+// Team returns CloudTeam when the repository is the cloud repo otherwise CoreTeam.
+func (e *Environment) Team() string {
+	if e.Repository == CloudRepo {
+		return CloudTeam
+	}
+	return CoreTeam
+}
+
 func readEvent() (*Event, error) {
 	f, err := os.Open(os.Getenv(githubEventPath))
 	if err != nil {

--- a/bot/internal/env/env.go
+++ b/bot/internal/env/env.go
@@ -132,8 +132,8 @@ func (e *Environment) IsCloudDeployBranch() bool {
 		(e.UnsafeBase == CloudProdBranch || e.UnsafeBase == CloudStagingBranch)
 }
 
-// Team returns CloudTeam when the repository is the cloud repo otherwise CoreTeam.
-func (e *Environment) Team() string {
+// RepoOwnerTeam returns CloudTeam when the repository is the cloud repo otherwise CoreTeam.
+func (e *Environment) RepoOwnerTeam() string {
 	if e.Repository == CloudRepo {
 		return CloudTeam
 	}

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -86,7 +86,12 @@ func isAllowedRobot(author string) bool {
 
 // Reviewer is a code reviewer.
 type Reviewer struct {
-	// Team the reviewer belongs to.
+	// Team the reviewer belongs to. This field is set when loading the configuration file
+	// based on whether the section being loaded is either CoreReviewers or CloudReviewers.
+	// DocsReviewers is automatically set to Core.
+	//
+	// Deprecated: we should remove the need for this field and detect by environment now
+	// that the teams have been split into their own sections in the configuration file.
 	Team string `json:"team"`
 	// Owner is true if the reviewer is a code or docs owner (required for all reviews).
 	Owner bool `json:"owner"`
@@ -176,13 +181,16 @@ func FromString(e *env.Environment, reviewers string) (*Assignments, error) {
 	if len(c.CodeReviewers) == 0 { // allow this change to deploy before updating the config file
 		switch e.RepoOwnerTeam() {
 		case env.CloudTeam:
-			c.CodeReviewers = c.CloudReviewers
+			c.CodeReviewers = setReviewerTeam(env.CloudTeam, c.CloudReviewers)
 		case env.CoreTeam:
-			c.CodeReviewers = c.CoreReviewers
+			c.CodeReviewers = setReviewerTeam(env.CoreTeam, c.CoreReviewers)
 		default:
 			return nil, trace.BadParameter("unable to detect code reviewers due to invalid team: %s", e.RepoOwnerTeam())
 		}
 	}
+
+	// team for all docs reviewers should be set to Core
+	c.DocsReviewers = setReviewerTeam(env.CoreTeam, c.DocsReviewers)
 
 	r, err := New(&c)
 	if err != nil {
@@ -591,6 +599,19 @@ func reviewsByAuthor(reviews []github.Review) map[string]string {
 	}
 
 	return m
+}
+
+// setReviewerTeam sets the Team field in each Reviewer of the reviewers map.
+//
+// NOTE: This is a hack so the team field doesn't need to be included in the config file.
+// Eventually we should remove the team field and use the environment since the config file
+// now separates cloud and core engineers.
+func setReviewerTeam(team string, reviewers map[string]Reviewer) map[string]Reviewer {
+	for name, r := range reviewers {
+		r.Team = team
+		reviewers[name] = r
+	}
+	return reviewers
 }
 
 const (

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -174,13 +174,13 @@ func FromString(e *env.Environment, reviewers string) (*Assignments, error) {
 	// both cloud and core repos without having to change the
 	// bot in a large number of places.
 	if len(c.CodeReviewers) == 0 { // allow this change to deploy before updating the config file
-		switch e.Team() {
+		switch e.RepoOwnerTeam() {
 		case env.CloudTeam:
 			c.CodeReviewers = c.CloudReviewers
 		case env.CoreTeam:
 			c.CodeReviewers = c.CoreReviewers
 		default:
-			return nil, trace.BadParameter("unable to detect code reviewers due to invalid team: %s", e.Team())
+			return nil, trace.BadParameter("unable to detect code reviewers due to invalid team: %s", e.RepoOwnerTeam())
 		}
 	}
 

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -107,11 +107,17 @@ type Config struct {
 	Rand Rand
 
 	// CodeReviewers and CodeReviewersOmit is a map of code reviews and code
-	// reviewers to omit.
+	// reviewers to omit. CodeReviewers is set to either CoreReviewers
+	// or CloudReviewers depending on the repository when the configuration
+	// file is loaded if CodeReviewers is empty.
 	CodeReviewers     map[string]Reviewer `json:"codeReviewers"`
-	CoreReviewers     map[string]Reviewer `json:"coreReviewers"`
-	CloudReviewers    map[string]Reviewer `json:"cloudReviewers"`
 	CodeReviewersOmit map[string]bool     `json:"codeReviewersOmit"`
+
+	// CoreReviewers and CloudReviewers defines reviewers for the respositories
+	// owned by the core and cloud teams. One of these is assigned to CodeReviewers
+	// depending on the repository when the configuration file is loaded.
+	CoreReviewers  map[string]Reviewer `json:"coreReviewers"`
+	CloudReviewers map[string]Reviewer `json:"cloudReviewers"`
 
 	// DocsReviewers and DocsReviewersOmit is a map of docs reviews and docs
 	// reviewers to omit.

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -1075,7 +1075,8 @@ func TestCheckInternal(t *testing.T) {
 
 // TestFromString tests if configuration is correctly read in from a string.
 func TestFromString(t *testing.T) {
-	r, err := FromString(reviewers)
+	e := &env.Environment{Repository: env.TeleportRepo}
+	r, err := FromString(e, reviewers)
 	require.NoError(t, err)
 
 	require.EqualValues(t, r.c.CodeReviewers, map[string]Reviewer{
@@ -1210,13 +1211,23 @@ func TestSingleApproverAuthors(t *testing.T) {
 
 const reviewers = `
 {
-	"codeReviewers": {
+	"coreReviewers": {
 		"1": {
 			"team": "Core",
 			"owner": true
 		},
 		"2": {
 			"team": "Core",
+			"owner": false
+		}
+	},
+	"cloudReviewers": {
+		"1": {
+			"team": "Cloud",
+			"owner": true
+		},
+		"2": {
+			"team": "Cloud",
 			"owner": false
 		}
 	},

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -1213,21 +1213,17 @@ const reviewers = `
 {
 	"coreReviewers": {
 		"1": {
-			"team": "Core",
 			"owner": true
 		},
 		"2": {
-			"team": "Core",
 			"owner": false
 		}
 	},
 	"cloudReviewers": {
 		"1": {
-			"team": "Cloud",
 			"owner": true
 		},
 		"2": {
-			"team": "Cloud",
 			"owner": false
 		}
 	},
@@ -1236,11 +1232,9 @@ const reviewers = `
     },
 	"docsReviewers": {
 		"4": {
-			"team": "Core",
 			"owner": true
 		},
 		"5": {
-			"team": "Core",
 			"owner": false
 		}
 	},

--- a/bot/main.go
+++ b/bot/main.go
@@ -178,7 +178,7 @@ func createBot(ctx context.Context, flags flags) (*bot.Bot, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	reviewer, err := review.FromString(flags.reviewers)
+	reviewer, err := review.FromString(environment, flags.reviewers)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR addresses the "Cross-Repo Reviewers" issue described in https://github.com/gravitational/shared-workflows/issues/205.

The current bot configuration data model doesn't allow an engineer to be a reviewer in both the cloud and core repositories. This is an issue because we now require the core team to submit PRs to the cloud repo to manage either tools they own (e.g. release server) or deploy a new version of a component they own (e.g. TAG). 

This PR provides a hacky solution that will allow us to change the bot config data model to include a cloud and core team section, while keeping the original code reviewers map in the bot so we don't have to change a large amount of code.