### PR TITLE
fix: review bot version

### DIFF
--- a/bot/go.mod
+++ b/bot/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/shared-workflows/bot
 
-go 1.18
+go 1.21
 
 require (
 	github.com/google/go-github/v37 v37.0.0


### PR DESCRIPTION
The review bot was updated to use the slices package and requires Go 1.21. We've changed the check workflow to use the stable version but need this PR to allow those fixes to pass the checks.