### PR TITLE
bot: Allow setB to be a single approver

### DIFF
--- a/bot/internal/bot/check.go
+++ b/bot/internal/bot/check.go
@@ -74,6 +74,7 @@ func (b *Bot) Check(ctx context.Context) error {
 	}
 
 	changes := classifyChanges(b.c, files)
+	log.Printf("Check: required approvals: %d", changes.ApproverCount)
 
 	if changes.Large {
 		comment := fmt.Sprintf("@%v - this PR will require admin approval to merge due to its size. "+

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -518,10 +518,14 @@ func (r *Assignments) checkInternalCodeReviews(e *env.Environment, changes env.C
 	// PRs can be approved if you either have multiple code owners that approve
 	// or code owner and code reviewer. An exception is for PRs that
 	// only modify paths that require a single approver.
-	if checkN(setA, reviews) >= changes.ApproverCount {
+	a := checkN(setA, reviews)
+	b := checkN(setB, reviews)
+	switch {
+	case changes.ApproverCount == 1 && (a >= 1 || b >= 1):
 		return nil
-	}
-	if check(setA, reviews) && check(setB, reviews) {
+	case a >= changes.ApproverCount:
+		return nil
+	case a > 0 && b > 0 && a+b >= changes.ApproverCount:
 		return nil
 	}
 


### PR DESCRIPTION
#206 added support for a single approver but did not include single approvers from group B. 

1. Updated the check logic to allow a single approval from setB
2. Added use cases to the internal unit test 
3. Added a log line to print the number of required approvers for a PR

