### PR TITLE
fix: Revert slices package from stdlib

### DIFF
--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -18,7 +18,6 @@ package bot
 
 import (
 	"context"
-	"slices"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -26,6 +25,8 @@ import (
 	"github.com/gravitational/shared-workflows/bot/internal/env"
 	"github.com/gravitational/shared-workflows/bot/internal/github"
 	"github.com/gravitational/shared-workflows/bot/internal/review"
+
+	"golang.org/x/exp/slices"
 )
 
 // Client implements the GitHub API.

--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -21,12 +21,11 @@ import (
 	"strings"
 
 	"github.com/gravitational/trace"
+	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/shared-workflows/bot/internal/env"
 	"github.com/gravitational/shared-workflows/bot/internal/github"
 	"github.com/gravitational/shared-workflows/bot/internal/review"
-
-	"golang.org/x/exp/slices"
 )
 
 // Client implements the GitHub API.

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package review
 
 import (
-	"slices"
 	"sort"
 	"testing"
 
 	"github.com/gravitational/shared-workflows/bot/internal/env"
 	"github.com/gravitational/shared-workflows/bot/internal/github"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 )
 
 // TestIsInternal checks if docs and code reviewers show up as internal.

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -20,10 +20,11 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/gravitational/shared-workflows/bot/internal/env"
-	"github.com/gravitational/shared-workflows/bot/internal/github"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
+
+	"github.com/gravitational/shared-workflows/bot/internal/env"
+	"github.com/gravitational/shared-workflows/bot/internal/github"
 )
 
 // TestIsInternal checks if docs and code reviewers show up as internal.


### PR DESCRIPTION
Many of the downstream actions that use this bot don't execute using the most recent Go version. Downgrade the slices package to use `golang.org/x/exp/slices` rather than the stdlib version only available in 1.21.5.