### PR TITLE
Add shared migration path to AccessGraphRepo

### DIFF
--- a/bot/internal/bot/verify.go
+++ b/bot/internal/bot/verify.go
@@ -43,7 +43,7 @@ func (b *Bot) verifyCloud(ctx context.Context) error {
 //
 //	map[repo]: [...path]
 var migrationConfig = map[string][]string{
-	env.AccessGraphRepo: {"migrations/public", "migrations/tenant"},
+	env.AccessGraphRepo: {"migrations/public", "migrations/shared", "migrations/tenant"},
 	env.CloudRepo:       {"db/salescenter/migrations"},
 }
 


### PR DESCRIPTION
Recently, Access Graph added a `shared` DB schema with their own migrations. This change adds the new path to the DB migrations verification logic.