### PR TITLE
cloud/fluxcd: Single reviewer for helm chart versions and image versions

### DIFF
--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -18,6 +18,7 @@ package bot
 
 import (
 	"context"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -186,6 +187,10 @@ func approverCount(authors, paths []string, author string, files []github.PullRe
 	}
 	for _, file := range files {
 		if !slices.ContainsFunc(paths, func(path string) bool {
+			wildcardMatch, err := filepath.Match(path, file.Name)
+			if err == nil && wildcardMatch {
+				return true
+			}
 			return strings.HasPrefix(file.Name, path)
 		}) {
 			return env.DefaultApproverCount

--- a/bot/internal/bot/bot_test.go
+++ b/bot/internal/bot/bot_test.go
@@ -361,6 +361,42 @@ func TestApproverCount(t *testing.T) {
 			expect: 1,
 		},
 		{
+			desc: "all files match wildcard",
+			files: []github.PullRequestFile{
+				{Name: "src/package/values.yaml"},
+				{Name: "src/package2/values.yaml"},
+			},
+			paths:  []string{"src/*/values.yaml"},
+			expect: 1,
+		},
+		{
+			desc: "all files match multiple wildcard",
+			files: []github.PullRequestFile{
+				{Name: "src/package/values.yaml"},
+				{Name: "docs/README.md"},
+			},
+			paths:  []string{"src/*/values.yaml", "*/*.md"},
+			expect: 1,
+		},
+		{
+			desc: "all files match wildcard or path",
+			files: []github.PullRequestFile{
+				{Name: "src/package/values.yaml"},
+				{Name: "lib/db.go"},
+			},
+			paths:  []string{"lib", "src/*/values.yaml"},
+			expect: 1,
+		},
+		{
+			desc: "one file doesn't match wildcard",
+			files: []github.PullRequestFile{
+				{Name: "src/package/values.yaml"},
+				{Name: "src/package/values2.yaml"},
+			},
+			paths:  []string{"src/*/values.yaml"},
+			expect: env.DefaultApproverCount,
+		},
+		{
 			desc: "all files matching multiple paths",
 			files: []github.PullRequestFile{
 				{Name: "lib/default.go"},

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -55,6 +55,13 @@ var (
 	singleApproverPaths = map[string][]string{
 		"cloud": []string{
 			"deploy/fluxcd/config/values.yaml",
+			"deploy/fluxcd/config/*/values.yaml",
+			"deploy/fluxcd/config/*/*/values.yaml",
+			"deploy/fluxcd/config/*/*/*/values.yaml",
+			"deploy/fluxcd/src/platform/*/values.helm.yaml",
+			"deploy/fluxcd/src/platform/*/helmrelease.yaml",
+			"deploy/fluxcd/src/platform/*/*/values.helm.yaml",
+			"deploy/fluxcd/src/platform/*/*/helmrelease.yaml",
 		},
 	}
 


### PR DESCRIPTION
This PR adds the ability to include a wildcard token (asterisk) in single approver paths. An asterisk will only match one path element (file/folder name) and does not span path-separators -- we don't get `.gitignore` style glob matching out of this change.

Wildcards are added to support a set of single approver files from the FluxCD portion of the cloud repo:
- `helmrelease.yaml` files contain the helm chart version which frequently gets updated during component upgrade
- `values.helm.yaml` files define a `configmap` that is fed into the `helmrelease` as values, we make changes to the values if we need to override an image version. 
