### PR TITLE
Ignore new TypeScript protobufs during size check

### DIFF
--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -268,6 +268,9 @@ func skipFileForSizeCheck(name string) bool {
 		strings.HasSuffix(name, ".pb.go") ||
 		strings.HasSuffix(name, "_pb.js") ||
 		strings.HasSuffix(name, "_pb.d.ts") ||
+		strings.HasSuffix(name, "_pb.ts") ||
+		strings.HasSuffix(name, "_pb.grpc-client.ts") ||
+		strings.HasSuffix(name, "_pb.grpc-server.ts") ||
 		strings.HasSuffix(name, ".json") ||
 		strings.Contains(name, "webassets/") ||
 		strings.Contains(name, "vendor/") ||


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/37009 uses a new library for protobufs which have a slightly different suffix than existing files. This PR makes it so that the bot ignores those files during size check, just like other generated protobuf files.