### PR TITLE
bot: Log the number of reviewers loaded

### DIFF
--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -175,6 +175,7 @@ func FromString(e *env.Environment, reviewers string) (*Assignments, error) {
 	if err := json.Unmarshal([]byte(reviewers), &c); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	log.Printf("Reviewers loaded with %d cloud and %d core reviewers", len(c.CloudReviewers), len(c.CoreReviewers))
 
 	r, err := New(&c)
 	if err != nil {


### PR DESCRIPTION
Log the number of reviewers loaded in order to help debug issues loading the reviewers data. 