### PR TITLE
bot: Fix preferred only filter for external authors

### DIFF
--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -587,6 +587,8 @@ func filterPreferredOnly(reviewers map[string]Reviewer, set []string, preferredO
 	for _, name := range set {
 		reviewer, ok := reviewers[name]
 		if !ok {
+			// set may only contain admin users that aren't also included in reviewers
+			filtered = append(filtered, name)
 			continue
 		}
 		if reviewer.PreferredOnly == preferredOnly {

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -1186,6 +1186,10 @@ func TestGetCodeReviewers(t *testing.T) {
 				"5": {Owner: false, PreferredReviewerFor: []string{"lib/srv/db"}},
 				"6": {Owner: false},
 			},
+			Admins: []string{
+				"100",
+				"200",
+			},
 		},
 	}
 
@@ -1236,6 +1240,15 @@ func TestGetCodeReviewers(t *testing.T) {
 				{Name: "lib/srv/db/engine.go"},
 			},
 			expected: []string{"1", "4", "5"},
+		},
+		{
+			description: "admins",
+			author:      "999",
+			files: []github.PullRequestFile{
+				{Name: "lib/srv/app.go"},
+				{Name: "lib/srv/db/engine.go"},
+			},
+			expected: []string{"100", "200"},
 		},
 	}
 


### PR DESCRIPTION
Fix the preferred only feature for external authors who are assigned admin reviewers.