### PR TITLE
bot: single-reviewer for multiple helmrelease/values in same folder

### DIFF
--- a/bot/internal/bot/bot_test.go
+++ b/bot/internal/bot/bot_test.go
@@ -389,7 +389,7 @@ func TestApproverCount(t *testing.T) {
 			expect: 1,
 		},
 		{
-			desc: "helmrelease files matche wildcard",
+			desc: "helmrelease files match wildcard",
 			files: []github.PullRequestFile{
 				{Name: "src/package/helmrelease-with-suffix.yaml"},
 				{Name: "src/package/prefix-helmrelease.yaml"},

--- a/bot/internal/bot/bot_test.go
+++ b/bot/internal/bot/bot_test.go
@@ -389,6 +389,16 @@ func TestApproverCount(t *testing.T) {
 			expect: 1,
 		},
 		{
+			desc: "helmrelease files matche wildcard",
+			files: []github.PullRequestFile{
+				{Name: "src/package/helmrelease-with-suffix.yaml"},
+				{Name: "src/package/prefix-helmrelease.yaml"},
+				{Name: "lib/db.go"},
+			},
+			paths:  []string{"lib", "src/*/*helmrelease*.yaml"},
+			expect: 1,
+		},
+		{
 			desc: "one file doesn't match wildcard",
 			files: []github.PullRequestFile{
 				{Name: "src/package/values.yaml"},

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -57,10 +57,10 @@ var (
 			"deploy/fluxcd/config/*/values.yaml",
 			"deploy/fluxcd/config/*/*/values.yaml",
 			"deploy/fluxcd/config/*/*/*/values.yaml",
-			"deploy/fluxcd/src/platform/*/values.helm.yaml",
-			"deploy/fluxcd/src/platform/*/helmrelease.yaml",
-			"deploy/fluxcd/src/platform/*/*/values.helm.yaml",
-			"deploy/fluxcd/src/platform/*/*/helmrelease.yaml",
+			"deploy/fluxcd/src/platform/*/*values.helm.yaml",
+			"deploy/fluxcd/src/platform/*/*helmrelease*.yaml",
+			"deploy/fluxcd/src/platform/*/*/*values.helm.yaml",
+			"deploy/fluxcd/src/platform/*/*/*helmrelease*.yaml",
 		},
 	}
 


### PR DESCRIPTION
Some of our flux source folders contain multiple `helmrelease.yaml` and `values.yaml` files. This PR adds wildcards to the filenames to support these scenarios.