### PR TITLE
Ignore `protobuf-ts` client files during size check

### DIFF
--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -276,6 +276,7 @@ func skipFileForSizeCheck(name string) bool {
 		strings.HasSuffix(name, "_pb.ts") ||
 		strings.HasSuffix(name, "_pb.grpc-client.ts") ||
 		strings.HasSuffix(name, "_pb.grpc-server.ts") ||
+		strings.HasSuffix(name, "_pb.client.ts") ||
 		strings.HasSuffix(name, ".json") ||
 		strings.Contains(name, "webassets/") ||
 		strings.Contains(name, "vendor/") ||


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/39230 switches the gRPC client from `grpc-js` to `protobuf-ts`. This PR makes it so that the bot ignores `protobuf-ts` files during size check, just like other generated protobuf files.

I didn't remove `_pb.grpc-client.ts`, because we still have a `grpc-js` protobufs in the shared process in Connect.