### PR TITLE
Pin GHA dependencies to SHA

### DIFF
--- a/.github/workflows/csv-lint.yaml
+++ b/.github/workflows/csv-lint.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@20576b4b9ed46d41e2d45a2256e5e2316dde6834 # v43.0.1
         with:
           files: |
             **/*.csv

--- a/.github/workflows/json-lint.yaml
+++ b/.github/workflows/json-lint.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v43.0.1
+        uses: tj-actions/changed-files@20576b4b9ed46d41e2d45a2256e5e2316dde6834 # v43.0.1
         with:
           files: |
             **/*.json


### PR DESCRIPTION
No functional change. This fixes [the "check github actions" workflow failures](https://github.com/gravitational/shared-workflows/actions/runs/8473925309/job/23219276923?pr=237) occurring on unrelated PRs.