### PR TITLE
Remove `shared-workflows` Security CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gravitational/dev-eng-leads @gravitational/security-team
+* @gravitational/dev-eng-leads


### PR DESCRIPTION
This change will ensure we've got the right review processes in place while the former maintainers are still around to help with changes. We're approaching two weeks out from that cutoff.

Particular to this repo, I think we may want to add some Tools reviewers.

cc @fheinecke @camscale