### PR TITLE
Pin dependency-review-action

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@5bbc3ba658137598168acb2ab73b21c432dd411b # v4.2.5
         with:
           fail-on-severity: ${{ inputs.fail-on-severity }}
           allow-licenses: 0BSD, Apache-2.0, BlueOak-1.0.0, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-3-Clause, BSD-2-Clause AND BSD-3-Clause, CC-BY-3.0, CC-BY-4.0, CC0-1.0, ISC, LGPL-2.1, MIT, MIT-0, MPL-2.0, ODC-By-1.0, OFL-1.1, Python-2.0, Unicode-DFS-2016, Unlicense, WTFPL, Zlib, (MIT OR Apache-2.0) AND Unicode-DFS-2016, Apache-2.0 AND BSD-3-Clause, ISC AND MIT, MIT AND Zlib, MIT AND BSD-3-Clause, MIT AND WTFPL


### PR DESCRIPTION
We noticed breakage when the last version landed (~33 minutes ago).   After closer inspection it looks like they intended to only scope the changes to a subset but it has impacted more than anticipated.  This should restore stability until upstream corrects and re-releases the fix.