### PR TITLE
Ignore snapshot files during PR size check.

### DIFF
--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -278,6 +278,7 @@ func skipFileForSizeCheck(name string) bool {
 		strings.HasSuffix(name, "_pb.grpc-server.ts") ||
 		strings.HasSuffix(name, "_pb.client.ts") ||
 		strings.HasSuffix(name, ".json") ||
+		strings.HasSuffix(name, ".snap") ||
 		strings.Contains(name, "webassets/") ||
 		strings.Contains(name, "vendor/") ||
 		isCRDRegex.MatchString(name)


### PR DESCRIPTION
Changes fx in web code might lead to large amount of lines in snapshot files which results in unnecessary requirement of admin approval for a PR.