### PR TITLE
Git library will use ISO 8601 format for consistency

### DIFF
--- a/libs/git/git.go
+++ b/libs/git/git.go
@@ -31,7 +31,8 @@ type Repo struct {
 }
 
 const (
-	gitTimeFormat = "Mon Jan 02 15:04:05 2006 -0700"
+	// git should be expected to to output in strict ISO 8601 format
+	gitTimeFormat = "2006-01-02T15:04:05-07:00"
 )
 
 // NewRepoFromDirectory initializes [Repo] from a directory.
@@ -61,18 +62,18 @@ func (r *Repo) BranchNameForHead() (string, error) {
 // TimestampForRef will get the timestamp for the given reference.
 // Will work for symbolic references such as tags, HEAD, branches
 func (r *Repo) TimestampForRef(ref string) (time.Time, error) {
-	t, err := r.RunCmd("show", "-s", "--format=%cd", ref)
+	t, err := r.RunCmd("show", "-s", "--format=%cI", ref)
 	if err != nil {
-		return time.Time{}, trace.Wrap(err, "can't get timestamp for ref")
+		return time.Time{}, trace.Wrap(err, trace.BadParameter("can't get timestamp for ref: %q", ref))
 	}
 	return time.Parse(gitTimeFormat, t)
 }
 
 // TimestampForLatestCommit will get the timestamp for the last commit.
 func (r *Repo) TimestampForLatestCommit() (time.Time, error) {
-	t, err := r.RunCmd("log", "-n", "1", "--format=%cd")
+	t, err := r.RunCmd("log", "-n", "1", "--format=%cI")
 	if err != nil {
-		return time.Time{}, trace.Wrap(err, "can't get timestamp for latest commit")
+		return time.Time{}, trace.Wrap(err, trace.BadParameter("can't get timestamp for latest commit on repo: %q", r.dir))
 	}
 	return time.Parse(gitTimeFormat, t)
 }


### PR DESCRIPTION
Git library didn't handle the timestamp returned from `git log --format=%cd` very well for days that are one digit e.g. `Aug 8 2024` couldn't be handled but `Aug 08 2024` could. To just simplify it and be less ambiguous the git format will now be ISO 8601 and time parsing will now handle that.