### PR TITLE
Bumping dependency version for libs

### DIFF
--- a/tools/changelog/go.mod
+++ b/tools/changelog/go.mod
@@ -4,7 +4,7 @@ go 1.22.4
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
-	github.com/gravitational/shared-workflows/libs v0.1.1
+	github.com/gravitational/shared-workflows/libs v0.1.2
 	github.com/gravitational/trace v1.4.0
 	github.com/stretchr/testify v1.8.3
 )

--- a/tools/changelog/go.sum
+++ b/tools/changelog/go.sum
@@ -779,8 +779,8 @@ github.com/googleapis/gax-go/v2 v2.7.0/go.mod h1:TEop28CZZQ2y+c0VxMUmu1lV+fQx57Q
 github.com/googleapis/gax-go/v2 v2.7.1/go.mod h1:4orTrqY6hXxxaUL4LHIPl6lGo8vAE38/qKbhSAKP6QI=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
-github.com/gravitational/shared-workflows/libs v0.1.1 h1:u8tlLhWDlMcAULsNZjTM1M+7eL09sffVk3zybGcAg84=
-github.com/gravitational/shared-workflows/libs v0.1.1/go.mod h1:ZIbzcw44BXUXF1GGt/+3sA9lhku6FrxvAXTgFOCJRsM=
+github.com/gravitational/shared-workflows/libs v0.1.2 h1:lWMol58dNaNd/78CcVXXZor8EZi2D/Ox6q6ESC2C7Og=
+github.com/gravitational/shared-workflows/libs v0.1.2/go.mod h1:ZIbzcw44BXUXF1GGt/+3sA9lhku6FrxvAXTgFOCJRsM=
 github.com/gravitational/trace v1.4.0 h1:TtTeMElVwMX21Udb1nmK2tpWYAAMJoyjevzKOaxIFZQ=
 github.com/gravitational/trace v1.4.0/go.mod h1:g79NZzwCjWS/VVubYowaFAQsTjVTohGi0hFbIWSyGoY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=


### PR DESCRIPTION
This fixes the `api.github.com` issue and will now return the proper URL.