### PR TITLE
Fixing the time format for parsing git timestamps

### DIFF
--- a/libs/git/cmd.go
+++ b/libs/git/cmd.go
@@ -40,11 +40,23 @@ func (r *Repo) RunCmd(args ...string) (string, error) {
 	cmd.Stderr = &stderr
 	cmd.Dir = r.dir
 
-	err := cmd.Run()
+	err := r.runner.Run(cmd)
 
 	if err != nil {
 		return strings.TrimSpace(stderr.String()), trace.Wrap(err)
 	}
 
 	return strings.TrimSpace(stdout.String()), nil
+}
+
+// commandRunner is a small interface that wraps the actual execution of the process.
+// This allows us to easily swap out the implementation for testing.
+type commandRunner interface {
+	Run(*exec.Cmd) error
+}
+
+type defaultRunner struct{}
+
+func (r *defaultRunner) Run(cmd *exec.Cmd) error {
+	return cmd.Run()
 }

--- a/libs/git/git.go
+++ b/libs/git/git.go
@@ -27,18 +27,20 @@ import (
 // Wrapper around the go-git library that also includes methods to execute git commands
 // on the system for missing compatability.
 type Repo struct {
-	dir string
+	dir    string
+	runner commandRunner
 }
 
 const (
 	// git should be expected to to output in strict ISO 8601 format
-	gitTimeFormat = "2006-01-02T15:04:05-07:00"
+	gitTimeFormat = "2006-01-02T15:04:05Z07:00"
 )
 
 // NewRepoFromDirectory initializes [Repo] from a directory.
 func NewRepoFromDirectory(dir string) (*Repo, error) {
 	return &Repo{
-		dir: dir,
+		dir:    dir,
+		runner: &defaultRunner{},
 	}, nil
 }
 

--- a/libs/git/git_test.go
+++ b/libs/git/git_test.go
@@ -17,11 +17,11 @@ func TestTimestampForRef(t *testing.T) {
 	}{
 		{
 			name:         "ISO 8601 with offset",
-			gitTimestamp: "2024-09-10T13:05:11-05:00",
+			gitTimestamp: "2024-09-10T13:30:47-05:00",
 		},
 		{
 			name:         "ISO 8601 in UTC",
-			gitTimestamp: "2024-09-10T13:05:11Z",
+			gitTimestamp: "2024-09-10T18:30:47Z",
 		},
 	}
 	for _, tt := range tests {

--- a/libs/git/git_test.go
+++ b/libs/git/git_test.go
@@ -1,0 +1,50 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimestampForRef(t *testing.T) {
+	// Mostly just a sanity test to prove that time parsing actually works
+	var tests = []struct {
+		name         string
+		gitTimestamp string
+	}{
+		{
+			name:         "ISO 8601 with offset",
+			gitTimestamp: "2024-09-10T13:05:11-05:00",
+		},
+		{
+			name:         "ISO 8601 in UTC",
+			gitTimestamp: "2024-09-10T13:05:11Z",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &Repo{
+				runner: &fakeRunner{
+					t:        t,
+					toStdout: tt.gitTimestamp,
+				},
+			}
+			_, err := repo.TimestampForRef("")
+			assert.NoError(t, err)
+		})
+	}
+}
+
+type fakeRunner struct {
+	t        *testing.T
+	toStdout string
+}
+
+func (r *fakeRunner) Run(cmd *exec.Cmd) error {
+	_, err := fmt.Fprint(cmd.Stdout, r.toStdout)
+	require.NoError(r.t, err)
+	return nil
+}

--- a/libs/go.mod
+++ b/libs/go.mod
@@ -6,12 +6,15 @@ require (
 	github.com/cli/go-gh/v2 v2.9.0
 	github.com/google/go-github/v63 v63.0.0
 	github.com/gravitational/trace v1.4.0
+	github.com/stretchr/testify v1.8.3
 	golang.org/x/oauth2 v0.21.0
 )
 
 require (
 	github.com/cli/safeexec v1.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/libs/go.sum
+++ b/libs/go.sum
@@ -997,6 +997,7 @@ golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
+golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
Previously would support timestamps with offsets but not timestamps in UTC time with "Z".

E.g. `2024-09-10T13:30:47-05:00` was supported but the equivalent in UTC time `2024-09-10T18:30:47Z` was not.

Also added some testing to prove it works and to provide a pattern for any future tests.