### PR TITLE
libs: Fix some git/github date/time issues

### DIFF
--- a/libs/git/git.go
+++ b/libs/git/git.go
@@ -30,11 +30,6 @@ type Repo struct {
 	dir string
 }
 
-const (
-	// git should be expected to to output in strict ISO 8601 format
-	gitTimeFormat = "2006-01-02T15:04:05-07:00"
-)
-
 // NewRepoFromDirectory initializes [Repo] from a directory.
 func NewRepoFromDirectory(dir string) (*Repo, error) {
 	return &Repo{
@@ -66,7 +61,7 @@ func (r *Repo) TimestampForRef(ref string) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, trace.Wrap(err, trace.BadParameter("can't get timestamp for ref: %q", ref))
 	}
-	return time.Parse(gitTimeFormat, t)
+	return time.Parse(time.RFC3339, t)
 }
 
 // TimestampForLatestCommit will get the timestamp for the last commit.
@@ -75,7 +70,7 @@ func (r *Repo) TimestampForLatestCommit() (time.Time, error) {
 	if err != nil {
 		return time.Time{}, trace.Wrap(err, trace.BadParameter("can't get timestamp for latest commit on repo: %q", r.dir))
 	}
-	return time.Parse(gitTimeFormat, t)
+	return time.Parse(time.RFC3339, t)
 }
 
 // GetParentReleaseBranch will attempt to find a parent branch for HEAD.

--- a/libs/github/pull_request.go
+++ b/libs/github/pull_request.go
@@ -80,10 +80,10 @@ func (c *Client) ListChangelogPullRequests(ctx context.Context, org, repo string
 }
 
 // dateRangeFormat takes in a date range and will format it for GitHub search syntax.
-// to can be empty and the format will be to search everything after from
+// to can be empty and the format will be to search everything after and including from.
 func dateRangeFormat(from, to time.Time) string {
 	if to == SearchTimeNow {
-		return fmt.Sprintf(">%s", from.Format(searchTimeLayout))
+		return fmt.Sprintf(">=%s", from.Format(searchTimeLayout))
 	}
 	return fmt.Sprintf("%s..%s", from.Format(searchTimeLayout), to.Format(searchTimeLayout))
 }


### PR DESCRIPTION
Use the standard `time.RFC3339` time format with `time.Parse()` so that
we support dates with a `Z` suffix instead of just a UTC offset. The
simple `Z` format is allowed by ISO8601 format so we should parse that.
It turns out that the `%cI` format passed to `git show` will return the
format with the `Z` suffix.

This fixes an error when running the changelog tool:

    parsing time "2024-09-25T02:35:11Z" as "2006-01-02T15:04:05-07:00": cannot parse "Z" as "-07:00"

Change the form of the github query date formatting to use `>=` instead
of `>` when just a start date is provided. The makes it consistent with
the range format (`a..b`) used when an end date is provided as the range
includes the first date. The changelog tool will need to be updated to
handle this by bumping the start dates by 1 second, but this should fix
an issue where an Enterprise commit for a PR that gets a release tag
ends up listed in two releases.

---

Once merged, I'll tag this as `libs/v0.1.3` and raise a PR that updates
`tools/changelog` to work with the changed date range logic. This should
resolve an issue that @stevenGravy reported where an Enterprise
changelog entry appeared on the release after it went in, due to being
right on the boundary/tag of the v16.4.0 release.
