### PR TITLE
changelog: Use fixed time parsing, adjust time query boundary

### DIFF
--- a/tools/changelog/go.mod
+++ b/tools/changelog/go.mod
@@ -4,7 +4,7 @@ go 1.22.4
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
-	github.com/gravitational/shared-workflows/libs v0.1.2
+	github.com/gravitational/shared-workflows/libs v0.1.3
 	github.com/gravitational/trace v1.4.0
 	github.com/stretchr/testify v1.8.3
 )

--- a/tools/changelog/go.sum
+++ b/tools/changelog/go.sum
@@ -781,6 +781,8 @@ github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gravitational/shared-workflows/libs v0.1.2 h1:lWMol58dNaNd/78CcVXXZor8EZi2D/Ox6q6ESC2C7Og=
 github.com/gravitational/shared-workflows/libs v0.1.2/go.mod h1:ZIbzcw44BXUXF1GGt/+3sA9lhku6FrxvAXTgFOCJRsM=
+github.com/gravitational/shared-workflows/libs v0.1.3 h1:XqJCPVdLXOO8jaLflEWKBEDLS3P2CT/w8SctSJPuHic=
+github.com/gravitational/shared-workflows/libs v0.1.3/go.mod h1:ZIbzcw44BXUXF1GGt/+3sA9lhku6FrxvAXTgFOCJRsM=
 github.com/gravitational/trace v1.4.0 h1:TtTeMElVwMX21Udb1nmK2tpWYAAMJoyjevzKOaxIFZQ=
 github.com/gravitational/trace v1.4.0/go.mod h1:g79NZzwCjWS/VVubYowaFAQsTjVTohGi0hFbIWSyGoY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/tools/changelog/main.go
+++ b/tools/changelog/main.go
@@ -81,6 +81,12 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Bump the time of the last release (both OSS and Enterprise) by 1 second
+	// as we do not want to include the commit in the last release.
+	timeLastRelease = timeLastRelease.Add(1 * time.Second)
+	timeLastEntRelease = timeLastEntRelease.Add(1 * time.Second)
+	timeLastEntMod = timeLastEntMod.Add(1 * time.Second)
+
 	// Generate changelogs
 	ctx := context.Background()
 	ossCLGen := &changelogGenerator{


### PR DESCRIPTION

Use libs/v0.1.3 for fixed time parsing for ISO8601 times with a `Z`
suffix, and adjust our commit time query to account for an boundary
condition error resulting in the occasional PR appearing in the
changelog of 2 releases.

---

I ran this version against the 16.4.0 and 16.4.1 release where the
previous version duplicated a changelog entry in each release and
verified that no longer happened.
