### PR TITLE
Changed environment loader to split environment names on '/'

### DIFF
--- a/tools/env-loader/README.md
+++ b/tools/env-loader/README.md
@@ -20,6 +20,11 @@ for and load the following files in order:
 * `<root path>/<env name>/<value set name>.*` (value set, specifically
   requested values)
 
+If the environment name contains a '/', the name is split and each component is
+searched for common files. That is, for an environment name of `publish/prod`,
+`<root path>/publish/common.*` and `<root path>/publish/prod/common.*` will
+also be loaded.
+
 The root path is typically the `environments` directory directly under the git
 repo root.
 

--- a/tools/env-loader/pkg/envloader.go
+++ b/tools/env-loader/pkg/envloader.go
@@ -80,7 +80,7 @@ func findGitRepoRoot() (string, error) {
 // NOTE: this assumes '/' is used a directory separator character. This is important so that
 // the same results are produced on multiple platforms.
 func findCommonFilesInPath(basePath, relativeSubdirectoryPath string) ([]string, error) {
-	relativeSubdirectoryPath = filepath.Clean(relativeSubdirectoryPath)
+	relativeSubdirectoryPath = filepath.Clean(filepath.ToSlash(relativeSubdirectoryPath))
 	subdirectoryNames := strings.Split(relativeSubdirectoryPath, EnvironmentNameDirectorySeparator)
 	directoryNamesToCheck := append([]string{"."}, subdirectoryNames...)
 

--- a/tools/env-loader/pkg/envloader.go
+++ b/tools/env-loader/pkg/envloader.go
@@ -80,7 +80,7 @@ func findGitRepoRoot() (string, error) {
 // NOTE: this assumes '/' is used a directory separator character. This is important so that
 // the same results are produced on multiple platforms.
 func findCommonFilesInPath(basePath, relativeSubdirectoryPath string) ([]string, error) {
-	relativeSubdirectoryPath = filepath.Clean(filepath.ToSlash(relativeSubdirectoryPath))
+	relativeSubdirectoryPath = filepath.ToSlash(filepath.Clean(relativeSubdirectoryPath))
 	subdirectoryNames := strings.Split(relativeSubdirectoryPath, EnvironmentNameDirectorySeparator)
 	directoryNamesToCheck := append([]string{"."}, subdirectoryNames...)
 


### PR DESCRIPTION
This is a minor change to the environment loader tool to allow for loading values from additional "common" files.

Previously, if an environment name contained a slash (i.e. `publish/prod`), the following file globs would be loaded:
* `<root env dir>/common.*`
* `<root env dir>/publish/prod/common.*`

This PR splits the name into components using the `/` character as a separator (on all platforms), and checks each part. Now, the following file globs would be loaded:
* `<root env dir>/common.*`
* `<root env dir>/publish/common.*`
* `<root env dir>/publish/prod/common.*`

This small but powerful change will greatly reduce the amount of duplication we have in cases [like this](https://github.com/gravitational/github-terraform/blob/main/gravitational/github-actions-values.tf#L293-L317).