### PR TITLE
Added support for loading multiple value sets

### DIFF
--- a/tools/env-loader/cmd/env-loader.go
+++ b/tools/env-loader/cmd/env-loader.go
@@ -32,7 +32,7 @@ const EnvVarPrefix = "ENV_LOADER_"
 
 type config struct {
 	Environment string
-	ValueSet    string
+	ValueSets   []string
 	Values      []string
 	Writer      string
 }
@@ -49,7 +49,7 @@ func parseCLI() *config {
 	kingpin.Flag("value-set", "Name of the value set to load").
 		Short('s').
 		Envar(EnvVarPrefix + "VALUE_SET").
-		StringVar(&c.ValueSet)
+		StringsVar(&c.ValueSets)
 
 	kingpin.Flag("values", "Name of the specific value to output").
 		Short('v').
@@ -69,7 +69,7 @@ func parseCLI() *config {
 
 func run(c *config) error {
 	// Load in values
-	envValues, err := envloader.LoadEnvironmentValues(c.Environment, c.ValueSet)
+	envValues, err := envloader.LoadEnvironmentValues(c.Environment, c.ValueSets)
 	if err != nil {
 		return trace.Wrap(err, "failed to load all environment values")
 	}

--- a/tools/env-loader/cmd/env-loader.go
+++ b/tools/env-loader/cmd/env-loader.go
@@ -48,7 +48,7 @@ func parseCLI() *config {
 
 	kingpin.Flag("value-set", "Name of the value set to load").
 		Short('s').
-		Envar(EnvVarPrefix + "VALUE_SET").
+		Envar(EnvVarPrefix + "VALUE_SETS").
 		StringsVar(&c.ValueSets)
 
 	kingpin.Flag("values", "Name of the specific value to output").

--- a/tools/env-loader/pkg/testdata/repos/basic repo/.environments/env1/testing1.abc
+++ b/tools/env-loader/pkg/testdata/repos/basic repo/.environments/env1/testing1.abc
@@ -1,3 +1,4 @@
 ---
 envLevelCommon2: set level
+setLevelCommon: testing1 level
 setLevel: set level

--- a/tools/env-loader/pkg/testdata/repos/basic repo/.environments/env1/testing2.abc
+++ b/tools/env-loader/pkg/testdata/repos/basic repo/.environments/env1/testing2.abc
@@ -1,0 +1,2 @@
+---
+setLevelCommon: testing2 level


### PR DESCRIPTION
This adds env-loader support for loading multiple value sets. Examples:
```shell
# Current
env-loader --environment stage/build
env-loader --environment stage/publish --value-set amis

# New
env-loader --environment prod/publish --value-set gpg-signing --value-set os-package-repos

# This replaces
VALUE_SETS="$(
cat << EOF
gpg-signing
os-package-repos
EOF
)"  # Mock - this is the format provided by GHA

echo "${VALUE_SETS}" | while read -r line; do
  env-loader --environment prod/publish --value-set "${line}"
done
```

The diff is somewhat messy but this essentially amounts to changing a CLI arg to a list type, and plumbing it to a `for` loop.