### PR TITLE
Add a workflow to check docs URLs

### DIFF
--- a/bot/go.mod
+++ b/bot/go.mod
@@ -5,6 +5,7 @@ go 1.23
 require (
 	github.com/google/go-github/v37 v37.0.0
 	github.com/gravitational/trace v1.5.0
+	github.com/spf13/afero v1.12.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/oauth2 v0.25.0
 )
@@ -15,5 +16,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/bot/go.sum
+++ b/bot/go.sum
@@ -14,6 +14,8 @@ github.com/gravitational/trace v1.5.0 h1:JbeL2HDGyzgy7G72Z2hP2gExEyA6Y2p7fCiSjyZ
 github.com/gravitational/trace v1.5.0/go.mod h1:dxezSkKm880IIDx+czWG8fq+pLnXjETBewMgN3jOBlg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
+github.com/spf13/afero v1.12.0/go.mod h1:ZTlWwG4/ahT8W7T0WQ5uYmjI9duaLQGy3Q2OAl4sk/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -27,6 +29,8 @@ golang.org/x/oauth2 v0.25.0 h1:CY4y7XT9v0cRI9oupztF8AgiIu99L/ksR/Xp/6jrZ70=
 golang.org/x/oauth2 v0.25.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/bot/internal/bot/doclinks.go
+++ b/bot/internal/bot/doclinks.go
@@ -1,0 +1,155 @@
+package bot
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/gravitational/trace"
+	"github.com/spf13/afero"
+)
+
+type staleDocURL struct {
+	Text string
+	Line int
+}
+
+// CheckDocsURLs opens each file changed by a pull request and checks whether
+// any URL paths for the Teleport documentation site within the file are
+// incorrect. An incorrect URL path is one that does not correspond to either:
+//   - a docs page in the docs/pages directory within teleportClonePath
+//   - the source of a redirect named in the docs configuration file at
+//     docs/config.json within teleportClonePath
+func (b *Bot) CheckDocsURLs(ctx context.Context, teleportClonePath string) error {
+	if teleportClonePath == "" {
+		return trace.BadParameter("unable to load Teleport documentation config with an empty path")
+	}
+
+	docsConfigPath := path.Join(teleportClonePath, "docs", "config.json")
+	f, err := os.Open(docsConfigPath)
+	if err != nil {
+		return trace.Errorf("unable to open docs config file at %v: %v", docsConfigPath, err)
+	}
+	defer f.Close()
+
+	var c DocsConfig
+	if err := json.NewDecoder(f).Decode(&c); err != nil {
+		return trace.Errorf("unable to load redirect configuration from %v: %v", docsConfigPath, err)
+	}
+
+	files, err := b.c.GitHub.ListFiles(ctx, b.c.Environment.Organization, b.c.Environment.Repository, b.c.Environment.Number)
+	if err != nil {
+		return trace.Errorf("unable to fetch files for PR %v: %v", b.c.Environment.Number, err)
+	}
+
+	fs := afero.NewOsFs()
+	data := make(staleDocsURLData)
+	for _, f := range files {
+		l, err := os.Open(f.Name)
+		if err != nil {
+			return trace.Errorf("unable to open PR file %v: %v", f.Name, err)
+		}
+		defer l.Close()
+
+		stale := staleDocsURLs(fs, c.Redirects, l, teleportClonePath)
+		if len(stale) == 0 {
+			continue
+		}
+		data[f.Name] = stale
+	}
+
+	if len(data) != 0 {
+		return trace.Errorf("found incorrect documentation URLs in the following files:\n%v", data)
+	}
+
+	return nil
+}
+
+type staleDocsURLData map[string][]staleDocURL
+
+const staleURLDataTempl = `{{ range $key, $val := . }}{{ $key }}:
+{{ range $val }}  - line {{ .Line }}: {{ .Text }}
+{{ end }}
+{{ end }}`
+
+func (s staleDocsURLData) String() string {
+	var buf bytes.Buffer
+	template.Must(template.New("").Parse(staleURLDataTempl)).Execute(&buf, s)
+	return buf.String()
+}
+
+var docURLRegexp = regexp.MustCompile(`goteleport.com(/([a-zA-Z0-9\._-]+/?)+)`)
+
+// docURLPathToFilePath converts urlpath, which is a valid redirect source, to
+// two possible docs page file paths that would correspond to urlpath, given
+// Docusaurus' logic for generating routes for category index pages.
+//
+// For example, "/admin-guides/database-access/" would map to either
+// "docs/pages/admin-guides/database-access/database-access.mdx" or
+// "docs/pages/admin-guides/database-access.mdx", depending on whether
+// database-access.mdx is a category index page.
+//
+// In the return value, standard page path comes first, followed by the category
+// index page path. We assume that the calling workflow runs on systems that
+// separate paths with forward slashes.
+func docURLPathToFilePath(urlpath string) (string, string) {
+	stem := strings.TrimSuffix(urlpath, "/")
+	short := path.Join(docsPrefix, stem) + ".mdx"
+	long := path.Join(docsPrefix, stem, path.Base(stem)) + ".mdx"
+	return short, long
+}
+
+// staleDocsURLs examines file to detect stale docs site URLs. A style docs site
+// URL is a URL of a docs page that neither corresponds to a file in fs nor a
+// redirect source in conf.
+//
+// staleDocsURLs assumes that docs paths are in fs and relative to
+// teleportClonePath.
+func staleDocsURLs(fs afero.Fs, conf []DocsRedirect, file io.Reader, teleportClonePath string) []staleDocURL {
+	sources := make(map[string]struct{})
+	for _, s := range conf {
+		sources[s.Source] = struct{}{}
+	}
+
+	res := []staleDocURL{}
+	sc := bufio.NewScanner(file)
+	sc.Split(bufio.ScanLines)
+	var line int
+	for sc.Scan() {
+		line++
+		m := docURLRegexp.FindAllStringSubmatch(sc.Text(), -1)
+		for _, a := range m {
+			urlpath := a[1]
+			// Redirect sources include a trailing "/".
+			if !strings.HasSuffix(urlpath, "/") {
+				urlpath += "/"
+			}
+
+			// While goteleport.com/docs URLs include the /docs/
+			// path segment, redirect sources do not.
+			urlpath = strings.TrimPrefix(urlpath, "/docs")
+
+			_, hasRedirect := sources[urlpath]
+			short, long := docURLPathToFilePath(urlpath)
+			_, err1 := fs.Stat(path.Join(teleportClonePath, short))
+			_, err2 := fs.Stat(path.Join(teleportClonePath, long))
+			if hasRedirect || err1 == nil || err2 == nil {
+				continue
+			}
+
+			res = append(res, staleDocURL{
+				Text: a[0],
+				Line: line,
+			})
+		}
+	}
+
+	return res
+}

--- a/bot/internal/bot/doclinks_test.go
+++ b/bot/internal/bot/doclinks_test.go
@@ -1,0 +1,209 @@
+package bot
+
+import (
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStaleDocsURLs(t *testing.T) {
+	cases := []struct {
+		description   string
+		sourceFile    string
+		docsFilenames []string
+		redirects     []DocsRedirect
+		expected      []staleDocURL
+	}{
+		{
+			description: "no errors, no redirects",
+			sourceFile:  `https://www.goteleport.com/docs/enroll-databases`,
+			docsFilenames: []string{
+				"docs/pages/enroll-databases.mdx",
+			},
+			redirects: []DocsRedirect{},
+			expected:  []staleDocURL{},
+		},
+		{
+			description: "one error, no redirects",
+			sourceFile:  `https://www.goteleport.com/docs/enroll-databases`,
+			docsFilenames: []string{
+				"docs/pages/enroll-dbs.mdx",
+			},
+			redirects: []DocsRedirect{},
+			expected: []staleDocURL{
+				{
+					Text: "goteleport.com/docs/enroll-databases",
+					Line: 1,
+				},
+			},
+		},
+		{
+			description: "no errors, one redirect",
+			sourceFile:  `https://www.goteleport.com/docs/enroll-databases`,
+			docsFilenames: []string{
+				"docs/pages/enroll-dbs.mdx",
+			},
+			redirects: []DocsRedirect{
+				{
+					Source:      "/enroll-databases/",
+					Destination: "/enroll-dbs/",
+					Permanent:   true,
+				},
+			},
+			expected: []staleDocURL{},
+		},
+		{
+			description: "error on line 3",
+			sourceFile: `This is a paragraph.
+
+This is a link to a [docs page](https://www.goteleport.com/docs/enroll-databases).`,
+			docsFilenames: []string{
+				"docs/pages/enroll-dbs.mdx",
+			},
+			redirects: []DocsRedirect{},
+			expected: []staleDocURL{
+				{
+					Text: "goteleport.com/docs/enroll-databases",
+					Line: 3,
+				},
+			},
+		},
+		{
+			description: "no subdomain in docs link, no error",
+			sourceFile:  `https://goteleport.com/docs/enroll-databases`,
+			docsFilenames: []string{
+				"docs/pages/enroll-databases.mdx",
+			},
+			redirects: []DocsRedirect{},
+			expected:  []staleDocURL{},
+		},
+		{
+			description: "query string in docs link, no error",
+			sourceFile:  `https://www.goteleport.com/docs/enroll-databases?scope="enterprise"`,
+			docsFilenames: []string{
+				"docs/pages/enroll-databases.mdx",
+			},
+			redirects: []DocsRedirect{},
+			expected:  []staleDocURL{},
+		},
+		{
+			description: "fragment in docs link, no error",
+			sourceFile:  `https://www.goteleport.com/docs/enroll-databases#step14-install-teleport`,
+			docsFilenames: []string{
+				"docs/pages/enroll-databases.mdx",
+			},
+			redirects: []DocsRedirect{},
+			expected:  []staleDocURL{},
+		},
+		{
+			description: "trailing slash in docs link, no error",
+			sourceFile:  `https://www.goteleport.com/docs/enroll-databases/`,
+			docsFilenames: []string{
+				"docs/pages/enroll-databases.mdx",
+			},
+			redirects: []DocsRedirect{},
+			expected:  []staleDocURL{},
+		},
+		{
+			description: "link to a Docusaurus index page, no error",
+			sourceFile:  `https://www.goteleport.com/docs/admin-guides/enroll-databases/`,
+			docsFilenames: []string{
+				"docs/pages/admin-guides/enroll-databases/enroll-databases.mdx",
+			},
+			redirects: []DocsRedirect{},
+			expected:  []staleDocURL{},
+		},
+		{
+			description: "link to a Docusaurus index page with redirect and no error",
+			sourceFile:  `https://www.goteleport.com/docs/admin-guides/enroll-databases/`,
+			docsFilenames: []string{
+				"docs/pages/admin-guides/add-databases/add-databases.mdx",
+			},
+			redirects: []DocsRedirect{
+				{
+					Source:      "/admin-guides/enroll-databases/",
+					Destination: "/admin-guides/add-databases/",
+					Permanent:   true,
+				},
+			},
+			expected: []staleDocURL{},
+		},
+	}
+
+	for _, c := range cases {
+		fs := afero.NewMemMapFs()
+		for _, n := range c.docsFilenames {
+			_, err := fs.Create(path.Join("docs", n))
+			assert.NoError(t, err)
+		}
+
+		t.Run(c.description, func(t *testing.T) {
+			urls := staleDocsURLs(fs, c.redirects, strings.NewReader(c.sourceFile), "docs")
+			assert.Equal(t, c.expected, urls)
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	expected := `my/file/1.go:
+  - line 1: https://goteleport.com/docs/page1
+  - line 10: https://goteleport.com/docs/page2
+  - line 5: https://goteleport.com/docs/page3
+
+my/file/2.go:
+  - line 304: https://goteleport.com/docs/page1
+  - line 1003: https://goteleport.com/docs/page2
+
+my/file/3.go:
+  - line 19: https://goteleport.com/docs/page1
+  - line 253: https://goteleport.com/docs/page2
+
+`
+
+	data := staleDocsURLData{
+		"my/file/1.go": []staleDocURL{
+			{Line: 1, Text: "https://goteleport.com/docs/page1"},
+			{Line: 10, Text: "https://goteleport.com/docs/page2"},
+			{Line: 5, Text: "https://goteleport.com/docs/page3"},
+		},
+
+		"my/file/2.go": []staleDocURL{
+			{Line: 304, Text: "https://goteleport.com/docs/page1"},
+			{Line: 1003, Text: "https://goteleport.com/docs/page2"},
+		},
+
+		"my/file/3.go": []staleDocURL{
+			{Line: 19, Text: "https://goteleport.com/docs/page1"},
+			{Line: 253, Text: "https://goteleport.com/docs/page2"},
+		},
+	}
+
+	assert.Equal(t, expected, data.String())
+}
+
+func Test_docURLPathToFilePath(t *testing.T) {
+	cases := []struct {
+		description   string
+		input         string
+		expectedShort string
+		expectedLong  string
+	}{
+		{
+			description:   "redirect source",
+			input:         "/admin-guides/databases/",
+			expectedShort: "docs/pages/admin-guides/databases.mdx",
+			expectedLong:  "docs/pages/admin-guides/databases/databases.mdx",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			short, long := docURLPathToFilePath(c.input)
+			assert.Equal(t, c.expectedShort, short)
+			assert.Equal(t, c.expectedLong, long)
+		})
+	}
+}

--- a/bot/main.go
+++ b/bot/main.go
@@ -82,6 +82,8 @@ func main() {
 		err = b.CheckChangelog(ctx)
 	case "docpaths":
 		err = b.CheckDocsPathsForMissingRedirects(ctx, flags.teleportClonePath)
+	case "docurls":
+		err = b.CheckDocsURLs(ctx, flags.teleportClonePath)
 	default:
 		err = trace.BadParameter("unknown workflow: %v", flags.workflow)
 	}


### PR DESCRIPTION
Like the workflow to check for necessary redirects to match renamed or deleted docs pages, this workflow takes the path to a `gravitational/teleport` clone. It finds mentions of Teleport docs site paths in each file changed by a PR and ensures that each path has a corresponding docs page or redirect source.