### PR TITLE
Fix tooling release issues

### DIFF
--- a/.github/workflows/reusable-cd.yaml
+++ b/.github/workflows/reusable-cd.yaml
@@ -38,7 +38,7 @@ jobs:
             # should move into this repo and replace this logic
             echo "should-release=true" >> "${GITHUB_OUTPUT}"
             
-            # Any '-' character means in the version means that it is a prerelease
+            # Any '-' character in the version means that it is a prerelease
             if [[ "${VERSION}" == *-* ]]; then
               echo "is-prerelease=true" >> "${GITHUB_OUTPUT}"
             fi

--- a/.github/workflows/reusable-cd.yaml
+++ b/.github/workflows/reusable-cd.yaml
@@ -26,6 +26,7 @@ jobs:
         run: set -e; echo "TOOL_NAME=$(make print-print-tool-name)" >> "${GITHUB_ENV}"
       - name: Create event-specific values
         id: setup
+        working-directory: ${{ inputs.tool-directory }}
         run: |
           # Determine if the workflow was triggered via a push to main or a tag
           # and get the version based off of that

--- a/.github/workflows/reusable-cd.yaml
+++ b/.github/workflows/reusable-cd.yaml
@@ -47,7 +47,7 @@ jobs:
             # Verify that the tag version matches the tool version
             MAKEFILE_VERSION="$(make print-version)"
             if [[ "${MAKEFILE_VERSION}" != "${VERSION}" ]]; then
-              echo "Makefile version '${MAKEFILE_VERSION}' does not match tag '${VERSION}'" >*2
+              echo "Makefile version '${MAKEFILE_VERSION}' does not match tag '${VERSION}'" >&2
               exit 1
             fi
           fi

--- a/.github/workflows/reusable-cd.yaml
+++ b/.github/workflows/reusable-cd.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-8core
     permissions:
       contents: write # Needed to create the release
       packages: write # Needed to upload the images to GHCR
@@ -118,6 +118,7 @@ jobs:
         env:
           VERSION: ${{ steps.setup.outputs.version }}
           IS_PRERELEASE: ${{ steps.setup.outputs.is-prerelease }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ "${IS_PRERELEASE}" == 'true' ]]; then
             EXTRA_FLAGS=("--prerelease")

--- a/.github/workflows/reusable-cd.yaml
+++ b/.github/workflows/reusable-cd.yaml
@@ -31,14 +31,15 @@ jobs:
           # and get the version based off of that
           if [[ "${GITHUB_REF}" =~ refs/tags/.* ]]; then
             # Transforms tag refs like refs/tags/tools/${TOOL_NAME}/v1.2.3 into v1.2.3
-            echo "version=${GITHUB_REF#refs/tags/tools/${TOOL_NAME}}" >> "${GITHUB_OUTPUT}"
+            VERSION="${GITHUB_REF#refs/tags/tools/${TOOL_NAME}/}"
+            echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
 
             # Eventually the parse-version action from the teleport.e repo
             # should move into this repo and replace this logic
             echo "should-release=true" >> "${GITHUB_OUTPUT}"
             
-            # Any '-' character means in a tag ref means that it is a prerelease
-            if [[ "${GITHUB_REF}" == *-* ]]; then
+            # Any '-' character means in the version means that it is a prerelease
+            if [[ "${VERSION}" == *-* ]]; then
               echo "is-prerelease=true" >> "${GITHUB_OUTPUT}"
             fi
           fi

--- a/.github/workflows/reusable-cd.yaml
+++ b/.github/workflows/reusable-cd.yaml
@@ -23,11 +23,12 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Get the name of the tool
         working-directory: ${{ inputs.tool-directory }}
-        run: set -e; echo "TOOL_NAME=$(make print-print-tool-name)" >> "${GITHUB_ENV}"
+        run: set -euo pipefail; echo "TOOL_NAME=$(make print-tool-name)" >> "${GITHUB_ENV}"
       - name: Create event-specific values
         id: setup
         working-directory: ${{ inputs.tool-directory }}
         run: |
+          set -euo pipefail
           # Determine if the workflow was triggered via a push to main or a tag
           # and get the version based off of that
           if [[ "${GITHUB_REF}" =~ refs/tags/.* ]]; then
@@ -62,6 +63,7 @@ jobs:
       - name: Build the project
         working-directory: ${{ inputs.tool-directory }}
         run: |
+          set -euo pipefail
           make tarball OS=linux ARCH=amd64
           make tarball OS=linux ARCH=arm64
           make tarball OS=darwin ARCH=amd64
@@ -128,6 +130,7 @@ jobs:
           IS_PRERELEASE: ${{ steps.setup.outputs.is-prerelease }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           if [[ "${IS_PRERELEASE}" == 'true' ]]; then
             EXTRA_FLAGS=("--prerelease")
           else

--- a/.github/workflows/reusable-cd.yaml
+++ b/.github/workflows/reusable-cd.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Get the name of the tool
         working-directory: ${{ inputs.tool-directory }}
-        run: set -e; echo "TOOL_NAME=$(make tool-name)" >> "${GITHUB_ENV}"
+        run: set -e; echo "TOOL_NAME=$(make print-print-tool-name)" >> "${GITHUB_ENV}"
       - name: Create event-specific values
         id: setup
         run: |
@@ -42,14 +42,21 @@ jobs:
             if [[ "${VERSION}" == *-* ]]; then
               echo "is-prerelease=true" >> "${GITHUB_OUTPUT}"
             fi
+
+            # Verify that the tag version matches the tool version
+            MAKEFILE_VERSION="$(make print-version)"
+            if [[ "${MAKEFILE_VERSION}" != "${VERSION}" ]]; then
+              echo "Makefile version '${MAKEFILE_VERSION}' does not match tag '${VERSION}'" >*2
+              exit 1
+            fi
           fi
 
       # Build the binaries
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version-file: '${{ inputs.tool-directory }}/go.mod'
-          cache-dependency-path: '${{ inputs.tool-directory }}/go.sum'
+          go-version-file: "${{ inputs.tool-directory }}/go.mod"
+          cache-dependency-path: "${{ inputs.tool-directory }}/go.sum"
 
       - name: Build the project
         working-directory: ${{ inputs.tool-directory }}
@@ -136,4 +143,3 @@ jobs:
           gh release create --title "${TOOL_NAME} ${VERSION}" --verify-tag \
             --generate-notes "${EXTRA_FLAGS[@]}" "${GITHUB_REF_NAME}" \
             "${RELEASE_TARBALLS[@]}"
-

--- a/tools/env-loader/Makefile
+++ b/tools/env-loader/Makefile
@@ -1,4 +1,6 @@
 TOOL_NAME = env-loader
 PACKAGE_PATH = ./cmd/env-loader.go
+VERSION = v0.0.0-dev.fred-8
+
 
 include ../repo-release-tooling/tooling.mk

--- a/tools/env-loader/Makefile
+++ b/tools/env-loader/Makefile
@@ -1,6 +1,6 @@
 TOOL_NAME = env-loader
 PACKAGE_PATH = ./cmd/env-loader.go
-VERSION = v0.0.0-dev.fred-8
+VERSION = v0.0.0-dev
 
 
 include ../repo-release-tooling/tooling.mk

--- a/tools/repo-release-tooling/tooling.mk
+++ b/tools/repo-release-tooling/tooling.mk
@@ -12,8 +12,11 @@ BINARY_NAME := $(BINARY_NAME).exe
 endif
 DOCKERFILE_PATH ?= ../repo-release-tooling/Dockerfile
 
-tool-name:
+print-tool-name:
 	@echo "$(TOOL_NAME)"
+
+print-version:
+	@echo "$(VERSION)"
 
 lint:
 	@golangci-lint run ./... --out-format colored-line-number -vvv
@@ -39,4 +42,4 @@ clean:
 	@rm -rf build/
 	@docker image rm -f "$(TOOL_NAME):$(CONTAINER_VERSION)" 2> /dev/null > /dev/null
 
-.PHONY: tool-name lint test binary tarball container-image clean
+.PHONY: print-tool-name print-version lint test binary tarball container-image clean


### PR DESCRIPTION
The env-loader release is failing due to this. Trim `/` from the version, and check only the `VERSION` to determine if a release is a prerelease or not.