### PR TITLE
env-loader: bug fixes

### DIFF
--- a/tools/env-loader/cmd/env-loader.go
+++ b/tools/env-loader/cmd/env-loader.go
@@ -43,7 +43,7 @@ func parseCLI() *config {
 
 	kingpin.Flag("environments-directory", "Path to the directory containing all environments, defaulting to the repo root").
 		Short('d').
-		Envar(EnvVarPrefix + "ENVIRONMENT").
+		Envar(EnvVarPrefix + "ENVIRONMENTS_DIRECTORY").
 		StringVar(&c.EnvironmentsDirectory)
 
 	kingpin.Flag("environment", "Name of the environment containing the values to load").
@@ -88,13 +88,15 @@ func run(c *config) error {
 	}
 
 	// Filter out values not requested
-	maps.DeleteFunc(envValues, func(key, _ string) bool {
-		return !slices.Contains(c.Values, key)
-	})
+	if len(c.Values) > 0 {
+		maps.DeleteFunc(envValues, func(key, _ string) bool {
+			return !slices.Contains(c.Values, key)
+		})
+	}
 
 	// Build the output string
 	writer := writers.FromName[c.Writer]
-	envValueOutput, err := writer.FormatEnvironmentValues(map[string]string{})
+	envValueOutput, err := writer.FormatEnvironmentValues(envValues)
 	if err != nil {
 		return trace.Wrap(err, "failed to format output values with writer %q", c.Writer)
 	}

--- a/tools/env-loader/cmd/env-loader.go
+++ b/tools/env-loader/cmd/env-loader.go
@@ -72,8 +72,7 @@ func parseCLI(args []string) *config {
 		Default("dotenv").
 		EnumVar(&c.Writer, slices.Collect(maps.Keys(writers.FromName))...)
 
-	kingpin.CommandLine.Parse(args)
-
+	kingpin.MustParse(kingpin.CommandLine.Parse(args))
 	return c
 }
 

--- a/tools/env-loader/cmd/env-loader.go
+++ b/tools/env-loader/cmd/env-loader.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"maps"
 	"os"
@@ -32,7 +33,7 @@ import (
 const EnvVarPrefix = "ENV_LOADER_"
 
 // This is a package-level var to assist with capturing stdout in tests
-var outputPrinter = fmt.Print
+var outputWriter io.Writer = os.Stdout
 
 type config struct {
 	EnvironmentsDirectory string
@@ -114,7 +115,7 @@ func run(c *config) error {
 	}
 
 	// Write it to stdout
-	_, err = outputPrinter(envValueOutput)
+	_, err = fmt.Fprint(outputWriter, envValueOutput)
 	if err != nil {
 		return trace.Wrap(err, "failed to print output %q", envValueOutput)
 	}

--- a/tools/env-loader/cmd/env-loader.go
+++ b/tools/env-loader/cmd/env-loader.go
@@ -114,7 +114,11 @@ func run(c *config) error {
 	}
 
 	// Write it to stdout
-	outputPrinter(envValueOutput)
+	_, err = outputPrinter(envValueOutput)
+	if err != nil {
+		return trace.Wrap(err, "failed to print output %q", envValueOutput)
+	}
+
 	return nil
 }
 

--- a/tools/env-loader/cmd/env-loader_test.go
+++ b/tools/env-loader/cmd/env-loader_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCli(t *testing.T) {
+	parseCLI([]string{})
+
+	flags := kingpin.CommandLine.Model().Flags
+	flagEnvVars := make([]string, 0, len(flags))
+	for _, flag := range flags {
+		if flag.Envar != "" {
+			flagEnvVars = append(flagEnvVars, flag.Envar)
+		}
+	}
+
+	uniqueFlagEnvVars := slices.Compact(slices.Clone(flagEnvVars))
+
+	require.ElementsMatch(t, flagEnvVars, uniqueFlagEnvVars, "not all flag env vars are unique")
+}
+
+func TestGetRequestedEnvValues(t *testing.T) {
+	tests := []struct {
+		desc           string
+		c              *config
+		expectedValues map[string]string
+	}{
+		{
+			desc: "specific values",
+			c: &config{
+				EnvironmentsDirectory: filepath.Join("..", "pkg", "testdata", "repos", "basic repo", ".environments"),
+				Environment:           "env1",
+				ValueSets: []string{
+					"testing1",
+				},
+				Values: []string{
+					"setLevel",
+					"envLevelCommon1",
+				},
+			},
+			expectedValues: map[string]string{
+				"setLevel":        "set level",
+				"envLevelCommon1": "env level",
+			},
+		},
+		{
+			desc: "full value set",
+			c: &config{
+				EnvironmentsDirectory: filepath.Join("..", "pkg", "testdata", "repos", "basic repo", ".environments"),
+				Environment:           "env1",
+				ValueSets: []string{
+					"testing1",
+				},
+			},
+			expectedValues: map[string]string{
+				"setLevel":        "set level",
+				"setLevelCommon":  "testing1 level",
+				"envLevelCommon1": "env level",
+				"envLevelCommon2": "set level",
+				"topLevelCommon1": "top level",
+				"topLevelCommon2": "env level",
+			},
+		},
+		{
+			desc: "specific env",
+			c: &config{
+				EnvironmentsDirectory: filepath.Join("..", "pkg", "testdata", "repos", "basic repo", ".environments"),
+				Environment:           "env1",
+			},
+			expectedValues: map[string]string{
+				"envLevelCommon1": "env level",
+				"envLevelCommon2": "env level",
+				"topLevelCommon1": "top level",
+				"topLevelCommon2": "env level",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		actualValues, err := getRequestedEnvValues(test.c)
+		require.NoError(t, err)
+		require.EqualValues(t, actualValues, test.expectedValues)
+	}
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		desc           string
+		c              *config
+		expectedOutput string
+	}{
+		{
+			desc: "specific values",
+			c: &config{
+				EnvironmentsDirectory: filepath.Join("..", "pkg", "testdata", "repos", "basic repo", ".environments"),
+				Environment:           "env1",
+				ValueSets: []string{
+					"testing1",
+				},
+				Values: []string{
+					"setLevel",
+					"envLevelCommon1",
+				},
+				Writer: "dotenv",
+			},
+			expectedOutput: "envLevelCommon1=env level\nsetLevel=set level\n",
+		},
+	}
+
+	for _, test := range tests {
+		// Setup to capture stdout
+		var output bytes.Buffer
+		var writtenLength int
+		var capturedErr error
+		outputPrinter = func(a ...any) (n int, err error) {
+			writtenLength, capturedErr = fmt.Fprint(&output, a...)
+			return writtenLength, capturedErr
+		}
+
+		err := run(test.c)
+
+		require.NoError(t, err)
+		require.NoError(t, capturedErr)
+		require.Equal(t, writtenLength, len(test.expectedOutput))
+		require.Equal(t, output.String(), test.expectedOutput)
+	}
+}

--- a/tools/env-loader/cmd/env-loader_test.go
+++ b/tools/env-loader/cmd/env-loader_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -87,7 +86,7 @@ func TestGetRequestedEnvValues(t *testing.T) {
 	for _, test := range tests {
 		actualValues, err := getRequestedEnvValues(test.c)
 		require.NoError(t, err)
-		require.EqualValues(t, actualValues, test.expectedValues)
+		require.EqualValues(t, test.expectedValues, actualValues)
 	}
 }
 
@@ -117,19 +116,14 @@ func TestRun(t *testing.T) {
 
 	for _, test := range tests {
 		// Setup to capture stdout
-		var output bytes.Buffer
-		var writtenLength int
-		var capturedErr error
-		outputPrinter = func(a ...any) (n int, err error) {
-			writtenLength, capturedErr = fmt.Fprint(&output, a...)
-			return writtenLength, capturedErr
-		}
+		var outputBytes bytes.Buffer
+		outputWriter = &outputBytes
 
 		err := run(test.c)
 
+		output := outputBytes.String()
+
 		require.NoError(t, err)
-		require.NoError(t, capturedErr)
-		require.Equal(t, writtenLength, len(test.expectedOutput))
-		require.Equal(t, output.String(), test.expectedOutput)
+		require.Equal(t, test.expectedOutput, output)
 	}
 }

--- a/tools/env-loader/pkg/envloader_test.go
+++ b/tools/env-loader/pkg/envloader_test.go
@@ -45,6 +45,12 @@ func ensureGitFSObjectsExist(t *testing.T) {
 		return os.WriteFile(gitPath, nil, 0400)
 	})
 
+	ensureGitFSObjectExist(t, "git repo with submodule", "directory", createGitFile)
+	ensureGitFSObjectExist(t, filepath.Join("git repo with submodule", "submodule"), "file", func(gitPath string) error {
+		// This path doesn't (currently) actually need to be created
+		return os.WriteFile(gitPath, []byte("gitdir: ../.git/modules/submodule\n"), 0400)
+	})
+
 	ensureGitFSObjectExist(t, "nested repos", "directory", createGitFile)
 	ensureGitFSObjectExist(t, filepath.Join("nested repos", "subdirectory"), "directory", createGitFile)
 }
@@ -100,6 +106,11 @@ func TestFindGitRepoRoot(t *testing.T) {
 			desc:             "nested repos",
 			workingDirectory: filepath.Join("nested repos", "subdirectory"),
 			expectedRoot:     filepath.Join("nested repos", "subdirectory"),
+		},
+		{
+			desc:             "from submodule",
+			workingDirectory: filepath.Join("git repo with submodule", "submodule"),
+			expectedRoot:     filepath.Join("git repo with submodule", "submodule"),
 		},
 	}
 


### PR DESCRIPTION
Fixed the following bugs with the env loader tool:
* `environments-directory` arg shared an environment variable with the `environments` arg
* No output would be produced if no values were specifically requested, instead of outputting all loaded values
* Git repo root not properly detected when the repo is a submodule
* Environment names with a `/` character in them would search individual components instead of the full path (i.e. `.environments/stage` and `.environments/build` instead of `.environments/stage/build`)