### PR TITLE
Release `amplify-preview` v0.0.1

### DIFF
--- a/tools/amplify-preview/Makefile
+++ b/tools/amplify-preview/Makefile
@@ -1,3 +1,4 @@
 TOOL_NAME = amplify-preview
+VERSION = v0.0.1
 
 include ../repo-release-tooling/tooling.mk

--- a/tools/amplify-preview/README.md
+++ b/tools/amplify-preview/README.md
@@ -36,37 +36,29 @@ on:
     paths:
       - 'docs/**'
   workflow_dispatch:
-  
 permissions:
-  # Permissions to write PR comment
   pull-requests: write
   id-token: write
-  
 jobs:
   amplify-preview:
     name: Get and post Amplify preview URL
-    runs-on: ubuntu-22.04-2core-arm64
-    environment: docs-amplify
+    runs-on: ubuntu-latest
     steps:
-    - name: Checkout shared-workflow
-      uses: actions/checkout@v4
-      with:
-        repository: gravitational/shared-workflows
-        sparse-checkout: |
-          tools
-
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
       with:
         aws-region: us-west-2
         role-to-assume: ${{ vars.IAM_ROLE }}
 
-    - name: Check Amplify job status test
-      uses: ./tools/amplify-preview
+    - name: Prepare Amplify Preview for this branch
+      uses: gravitational/shared-workflows/tools/amplify-preview@tools/amplify-preview/v0.0.1
       with:
         app_ids: ${{ vars.AMPLIFY_APP_IDS }}
-        create_branches: "true"
+        # "create_branches" can be disabled if amplify branch auto discovery and auto build enabled
+        # https://docs.aws.amazon.com/amplify/latest/userguide/pattern-based-feature-branch-deployments.html
+        create_branches: "true" 
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        # when "wait" is disabled, GHA won't wait for build to complete
         wait: "true"
 ```
 

--- a/tools/amplify-preview/action.yaml
+++ b/tools/amplify-preview/action.yaml
@@ -17,6 +17,18 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Workaround go cache issue
+      # It seems like `setup-go` can't use for cache files outside of ${{ github.workspace }}
+      # https://github.com/actions/setup-go/issues/467#issuecomment-2551300160
+      shell: bash
+      run: |
+        # Work around setup-go caching issue
+        mkdir -p ${{ github.workspace }}/.tmp/actions/cache/amplify-preview
+        go_sum_path=${{ github.workspace }}/.tmp/actions/cache/amplify-preview/go.sum
+        cp ${{ github.action_path }}/go.sum ${{ github.workspace }}/.tmp/actions/cache/amplify-preview/
+        echo "go_sum_path=${go_sum_path}" >> $GITHUB_OUTPUT
+      id: cache_workaround
+
     - name: Extract branch name
       shell: bash
       run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
@@ -24,8 +36,8 @@ runs:
 
     - uses: actions/setup-go@v5
       with:
-        go-version-file: tools/amplify-preview/go.mod
-        cache-dependency-path: tools/amplify-preview/go.sum
+        go-version-file: ${{ github.action_path }}/go.mod
+        cache-dependency-path: ${{ steps.cache_workaround.outputs.go_sum_path }}
 
     - name: Amplify Preview
       env:
@@ -35,5 +47,5 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         WAIT: ${{ inputs.wait }} 
       shell: bash
-      run: |
-        pushd ./tools/amplify-preview/; go run ./; popd
+      working-directory: ${{ github.action_path }}
+      run: go run .

--- a/tools/amplify-preview/go.mod
+++ b/tools/amplify-preview/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.32.6
 	github.com/aws/aws-sdk-go-v2/config v1.28.6
 	github.com/aws/aws-sdk-go-v2/service/amplify v1.27.5
-	github.com/gravitational/shared-workflows/libs v0.1.3
+	github.com/gravitational/shared-workflows/libs v0.1.4
 )
 
 require (
@@ -33,5 +33,3 @@ require (
 	golang.org/x/oauth2 v0.21.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/gravitational/shared-workflows/libs => ../../libs/

--- a/tools/amplify-preview/go.sum
+++ b/tools/amplify-preview/go.sum
@@ -807,6 +807,8 @@ github.com/googleapis/gax-go/v2 v2.7.0/go.mod h1:TEop28CZZQ2y+c0VxMUmu1lV+fQx57Q
 github.com/googleapis/gax-go/v2 v2.7.1/go.mod h1:4orTrqY6hXxxaUL4LHIPl6lGo8vAE38/qKbhSAKP6QI=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gravitational/shared-workflows/libs v0.1.4 h1:PW5xkoh5r+OKCFG9JwJkcCu5gKK41stQtnUBfhNKpaI=
+github.com/gravitational/shared-workflows/libs v0.1.4/go.mod h1:hzF3OgNdM/Mrgovq++B3ZymG58p54Ccjb8sbPZGfp08=
 github.com/gravitational/trace v1.4.0 h1:TtTeMElVwMX21Udb1nmK2tpWYAAMJoyjevzKOaxIFZQ=
 github.com/gravitational/trace v1.4.0/go.mod h1:g79NZzwCjWS/VVubYowaFAQsTjVTohGi0hFbIWSyGoY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=


### PR DESCRIPTION
### Summary

Release v0.0.1 of `amplify-preview` action.

### Testing
- https://github.com/gravitational/docs-website/pull/24
- https://github.com/gravitational/docs-website/actions/runs/12392686135/job/34592385727?pr=24
- https://github.com/gravitational/teleport/pull/48512
- https://github.com/gravitational/shared-workflows/pull/287