### PR TITLE
env-loader: Added missing license headers

### DIFF
--- a/tools/env-loader/pkg/envloader_test.go
+++ b/tools/env-loader/pkg/envloader_test.go
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2024 Gravitational, Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package envloader
 
 import (

--- a/tools/env-loader/pkg/loaders/subloader_test.go
+++ b/tools/env-loader/pkg/loaders/subloader_test.go
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2024 Gravitational, Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package loaders
 
 import (

--- a/tools/env-loader/pkg/loaders/yaml_test.go
+++ b/tools/env-loader/pkg/loaders/yaml_test.go
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2024 Gravitational, Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package loaders
 
 import (

--- a/tools/env-loader/pkg/values/value.go
+++ b/tools/env-loader/pkg/values/value.go
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2024 Gravitational, Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package values
 
 import (

--- a/tools/env-loader/pkg/values/value_test.go
+++ b/tools/env-loader/pkg/values/value_test.go
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2024 Gravitational, Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package values
 
 import (

--- a/tools/env-loader/pkg/writers/gha-mask_test.go
+++ b/tools/env-loader/pkg/writers/gha-mask_test.go
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2024 Gravitational, Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package writers
 
 import (

--- a/tools/env-loader/pkg/writers/writer_test.go
+++ b/tools/env-loader/pkg/writers/writer_test.go
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2024 Gravitational, Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package writers
 
 import (


### PR DESCRIPTION
A few env-loader files are missing license headers. This adds them.