### PR TITLE
Add Apache-2.0 variant

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -66,6 +66,7 @@ jobs:
             (MIT OR Apache-2.0) AND Unicode-DFS-2016,
             0BSD AND ISC AND MIT,
             0BSD,
+            Apache-2.0 AND BSD-2-Clause AND CC0-1.0 AND ISC AND MIT,
             Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT,
             Apache-2.0 AND BSD-3-Clause,
             Apache-2.0,


### PR DESCRIPTION
Similar to https://github.com/gravitational/shared-workflows/pull/305/ this PR will add another variant/combo and various licenses. Idealy we could manage this in some sort of "check if each of these invidually" are included, but idk how the legallity of licenses work so Ill just follow prior work here

related PR failure
https://github.com/gravitational/teleport/actions/runs/12911052502/job/36002924223?pr=51356#step:3:19