### PR TITLE
Release env-loader v0.0.5

### DIFF
--- a/tools/env-loader/Makefile
+++ b/tools/env-loader/Makefile
@@ -1,6 +1,6 @@
 TOOL_NAME = env-loader
 PACKAGE_PATH = ./cmd/env-loader.go
-VERSION = v0.0.4
+VERSION = v0.0.5
 
 
 include ../repo-release-tooling/tooling.mk


### PR DESCRIPTION
This will create a release for the GH action used in our release pipelines.