### PR TITLE
Revert "Backport merged commit SHA instead of individual commits (#313)"

### DIFF
--- a/bot/internal/bot/backport.go
+++ b/bot/internal/bot/backport.go
@@ -46,7 +46,7 @@ func (b *Bot) Backport(ctx context.Context) error {
 		return trace.BadParameter("automatic backports are only supported for internal contributors")
 	}
 
-	pull, err := b.c.GitHub.GetPullRequest(ctx,
+	pull, err := b.c.GitHub.GetPullRequestWithCommits(ctx,
 		b.c.Environment.Organization,
 		b.c.Environment.Repository,
 		b.c.Environment.Number)
@@ -155,7 +155,7 @@ func (b *Bot) Backport(ctx context.Context) error {
 // BackportLocal executes dry run backport workflow locally. No git commands
 // are actually executed, just printed in the console.
 func (b *Bot) BackportLocal(ctx context.Context, branch string) error {
-	pull, err := b.c.GitHub.GetPullRequest(ctx,
+	pull, err := b.c.GitHub.GetPullRequestWithCommits(ctx,
 		b.c.Environment.Organization,
 		b.c.Environment.Repository,
 		b.c.Environment.Number)
@@ -236,15 +236,16 @@ func (b *Bot) createBackportBranch(ctx context.Context, organization string, rep
 		return trace.Wrap(err)
 	}
 
-	// Cherry-pick the _merged_ commit on the base branch instead of
-	// the individual commits from the PR to the backport branch.
-	if err := git("cherry-pick", pull.MergeCommitSHA); err != nil {
-		// If cherry-pick fails with conflict, abort it, otherwise we
-		// won't be able to switch branch for the next backport.
-		if errAbrt := git("cherry-pick", "--abort"); errAbrt != nil {
-			return trace.NewAggregate(err, errAbrt)
+	// Cherry-pick all commits from the PR to the backport branch.
+	for _, commit := range pull.Commits {
+		if err := git("cherry-pick", commit); err != nil {
+			// If cherry-pick fails with conflict, abort it, otherwise we
+			// won't be able to switch branch for the next backport.
+			if errAbrt := git("cherry-pick", "--abort"); errAbrt != nil {
+				return trace.NewAggregate(err, errAbrt)
+			}
+			return trace.Wrap(err)
 		}
-		return trace.Wrap(err)
 	}
 
 	// Push the backport branch to Github.

--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -50,6 +50,9 @@ type Client interface {
 	// GetPullRequest returns a specific Pull Request.
 	GetPullRequest(ctx context.Context, organization string, repository string, number int) (github.PullRequest, error)
 
+	// GetPullRequestWithCommits returns a specific Pull Request with commits.
+	GetPullRequestWithCommits(ctx context.Context, organization string, repository string, number int) (github.PullRequest, error)
+
 	// CreatePullRequest will create a Pull Request.
 	CreatePullRequest(ctx context.Context, organization string, repository string, title string, head string, base string, body string, draft bool) (int, error)
 


### PR DESCRIPTION
This reverts commit ed99ff62ba6f4adb0095c64a914a588f19e5d5db.