### PR TITLE
Add MIT unicode variant

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -83,6 +83,7 @@ jobs:
             ISC AND MIT,
             ISC,
             LGPL-2.1,
+            LicenseRef-scancode-unicode AND MIT,
             MIT AND BSD-3-Clause,
             MIT AND WTFPL,
             MIT AND Zlib,


### PR DESCRIPTION
We have a dependency update in the web packages that are failing due to some missing licenses/variants. From [reading our open source policy](https://github.com/gravitational/company-policies/blob/2a3a81e695941cfeb035b0fe6a1ca30792d10aef/Open-Source-Policy.md#open-source-use) ibelieve these licenses fall under "good to go". 

https://github.com/gravitational/teleport/actions/runs/13166964916/job/36749302798?pr=51767#step:3:19