### PR TITLE
Support decoding `--reviewers` as plain-text JSON

### DIFF
--- a/bot/main.go
+++ b/bot/main.go
@@ -149,7 +149,7 @@ func parseFlags() (flags, error) {
 
 	var decodedReviewers string
 	// Support base64-encoded JSON reviewer string and just JSON without base64 encoding
-	if reviewers != nil && strings.Contains(*reviewers, "{") {
+	if strings.Contains(*reviewers, "{") {
 		decodedReviewers = *reviewers
 	} else {
 		reviewerBytes, err := base64.StdEncoding.DecodeString(*reviewers)

--- a/bot/main.go
+++ b/bot/main.go
@@ -147,9 +147,16 @@ func parseFlags() (flags, error) {
 		return flags{}, trace.BadParameter("reviewers required for assign and check")
 	}
 
-	data, err := base64.StdEncoding.DecodeString(*reviewers)
-	if err != nil {
-		return flags{}, trace.Wrap(err)
+	var decodedReviewers string
+	// Support base64-encoded JSON reviewer string and just JSON without base64 encoding
+	if reviewers != nil && strings.Contains(*reviewers, "{") {
+		decodedReviewers = *reviewers
+	} else {
+		reviewerBytes, err := base64.StdEncoding.DecodeString(*reviewers)
+		if err != nil {
+			return flags{}, trace.Wrap(err)
+		}
+		decodedReviewers = string(reviewerBytes)
 	}
 
 	stats, err := base64.StdEncoding.DecodeString(*baseStats)
@@ -160,7 +167,7 @@ func parseFlags() (flags, error) {
 	return flags{
 		workflow:          *workflow,
 		token:             *token,
-		reviewers:         string(data),
+		reviewers:         decodedReviewers,
 		local:             *local,
 		org:               *org,
 		repo:              *repo,

--- a/bot/main.go
+++ b/bot/main.go
@@ -149,7 +149,7 @@ func parseFlags() (flags, error) {
 
 	var decodedReviewers string
 	// Support base64-encoded JSON reviewer string and just JSON without base64 encoding
-	if strings.Contains(*reviewers, "{") {
+	if strings.HasPrefix(*reviewers, "{") {
 		decodedReviewers = *reviewers
 	} else {
 		reviewerBytes, err := base64.StdEncoding.DecodeString(*reviewers)

--- a/bot/main_test.go
+++ b/bot/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/base64"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFlagsReviewers(t *testing.T) {
+	dummyArgs := []string{
+		os.Args[0],
+		"-workflow",
+		"dummy-value",
+		"-token",
+		"dummy-value",
+	}
+
+	flagName := "-reviewers"
+	testValueJSON := `{"key": "value"}`
+	testValueBase64 := base64.StdEncoding.EncodeToString([]byte(testValueJSON))
+
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError) // Reset the flag lib
+	os.Args = append(dummyArgs, flagName, testValueBase64)
+	b64Flags, err := parseFlags()
+	require.NoError(t, err)
+
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError) // Reset the flag lib
+	os.Args = append(dummyArgs, flagName, testValueJSON)
+	plainTextFlags, err := parseFlags()
+	require.NoError(t, err)
+
+	assert.Equal(t, b64Flags.reviewers, plainTextFlags.reviewers)
+}

--- a/bot/main_test.go
+++ b/bot/main_test.go
@@ -33,5 +33,10 @@ func TestParseFlagsReviewers(t *testing.T) {
 	plainTextFlags, err := parseFlags()
 	require.NoError(t, err)
 
+	// Verify that the results are the same regardless of whether or not the reviewers
+	// flag is base64 encoded
 	assert.Equal(t, b64Flags.reviewers, plainTextFlags.reviewers)
+
+	// Basic checks
+	assert.Equal(t, testValueJSON, b64Flags.reviewers)
 }


### PR DESCRIPTION
The shared-workflows bot currently only supports decoding the `--reviewers` flag as a base64-encoded JSON string. For example, rather than

```json
{
  "reviewer-group-1": {
    "username": {
        ... // Repeat for 100+ lines
```

the tool requires the value as `ewogICJyZXZpZXdlci1ncm91cC0xIjogewogICAgInVzZXJuYW1lIjogewogICAgICAgIC4uLiAvLyBSZXBlYXQgZm9yIDEwMCsgbGluZXMK...`. For those of us who cannot base64-decode a string in their head, this is really difficult to read and debug.

Previously this was needed because GHA environment variables/secrets do not "play nice" with structured multiline data. However, now that we're starting to use [`env-loader`](https://github.com/gravitational/shared-workflows/tree/main/tools/env-loader) for these values, we can support plain-text JSON without issue.

This change is fully backwards compatible with all current uses of the bot.