### PR TITLE
Implementing GitHub webhook handler

### DIFF
--- a/libs/github/webhook/webhook.go
+++ b/libs/github/webhook/webhook.go
@@ -1,0 +1,141 @@
+package webhook
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/go-github/v63/github"
+)
+
+// EventHandlerFunc is a function that handles a webhook event.
+// The function should return an error if the event could not be handled.
+// If the error is not nil, the webhook will respond with a 500 Internal Server Error.
+//
+// It is important that this is non-blocking and does not perform any long-running operations.
+// GitHub will close the connection if the webhook does not respond within 10 seconds.
+//
+// Example usage:
+//
+//	func(event interface{}) error {
+//		switch event := event.(type) {
+//			case *github.CommitCommentEvent:
+//				processCommitCommentEvent(event)
+//			case *github.CreateEvent:
+//				processCreateEvent(event)
+//				...
+//		}
+//		return nil
+//	}
+type EventHandlerFunc func(event interface{}) error
+
+// Handler is an implementation of [http.Handler] that handles GitHub webhook events.
+type Handler struct {
+	eventHandler EventHandlerFunc
+	secretToken  []byte
+	log          *slog.Logger
+}
+
+var _ http.Handler = &Handler{}
+
+type Opt func(*Handler) error
+
+// WithSecretToken sets the secret token for the webhook.
+// The secret token is used to create a hash of the request body, which is sent in the X-Hub-Signature header.
+// If not set, the webhook will not verify the signature of the request.
+//
+// For more information, see: https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+func WithSecretToken(secretToken []byte) Opt {
+	return func(p *Handler) error {
+		p.secretToken = secretToken
+		return nil
+	}
+}
+
+// WithLogger sets the logger for the webhook.
+func WithLogger(log *slog.Logger) Opt {
+	return func(p *Handler) error {
+		p.log = log
+		return nil
+	}
+}
+
+var defaultOpts = []Opt{
+	WithLogger(slog.Default()),
+}
+
+// NewHandler creates a new webhook handler.
+func NewHandler(eventHandler EventHandlerFunc, opts ...Opt) *Handler {
+	h := Handler{
+		eventHandler: eventHandler,
+	}
+	for _, opt := range defaultOpts {
+		opt(&h)
+	}
+
+	for _, opt := range opts {
+		opt(&h)
+	}
+	return &h
+}
+
+// Headers is a list of special headers that are sent with a webhook request.
+// For more information, see: https://docs.github.com/en/webhooks/webhook-events-and-payloads#delivery-headers
+type Headers struct {
+	// GithubHookID is the unique identifier of the webhook.
+	GithubHookID string
+	// GithubEvent is the type of event that triggered the delivery.
+	GithubEvent string
+	// GithubDelivery is a globally unique identifier (GUID) to identify the event
+	GithubDelivery string
+	// GitHubHookInstallationTargetType is the type of resource where the webhook was created.
+	GitHubHookInstallationTargetType string
+	// GitHubHookInstallationTargetID is the unique identifier of the resource where the webhook was created.
+	GitHubHookInstallationTargetID string
+
+	// HubSignature256 is the HMAC hex digest of the response body.
+	// Is generated with the SHA-256 algorithm with a shared secret used as the HMAC key.
+	// This header will be sent if the webhook is configured with a secret.
+	HubSignature256 string
+}
+
+// ServeHTTP handles a webhook request.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Parse headers for debugging and audit purposes.
+	var head Headers
+	head.GithubHookID = r.Header.Get("X-GitHub-Hook-ID")
+	head.GithubEvent = r.Header.Get("X-GitHub-Event")
+	head.GithubDelivery = r.Header.Get("X-GitHub-Delivery")
+	head.GitHubHookInstallationTargetType = r.Header.Get("X-GitHub-Hook-Installation-Target-Type")
+	head.GitHubHookInstallationTargetID = r.Header.Get("X-GitHub-Hook-Installation-Target-ID")
+	head.HubSignature256 = r.Header.Get("X-Hub-Signature-256")
+
+	payload, err := github.ValidatePayload(r, h.secretToken) // If secretToken is empty, the signature will not be verified.
+	if err != nil {
+		h.log.Warn("webhook validation failed", "headers", head)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	event, err := github.ParseWebHook(head.GithubEvent, payload)
+	if err != nil {
+		h.log.Error("failed to parse webhook event", "error", err)
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.eventHandler(event); err != nil {
+		h.log.Error("failed to handle webhook event", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Respond to the request.
+	w.WriteHeader(http.StatusOK)
+}
+
+// String returns a string representation of the Headers.
+func (h *Headers) String() string {
+	return fmt.Sprintf("GithubHookID: %s\nGithubEvent: %s\nGithubDelivery: %s\nGitHubHookInstallationTargetType: %s\nGitHubHookInstallationTargetID: %s\nHubSignature256: %s\n",
+		h.GithubHookID, h.GithubEvent, h.GithubDelivery, h.GitHubHookInstallationTargetType, h.GitHubHookInstallationTargetID, h.HubSignature256)
+}

--- a/tools/approval-service/go.mod
+++ b/tools/approval-service/go.mod
@@ -1,3 +1,9 @@
 module github.com/gravitational/shared-workflows/tools/approval-service
 
 go 1.23.5
+
+require (
+	github.com/google/go-github/v63 v63.0.0 // indirect
+	github.com/google/go-github/v69 v69.1.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
+)

--- a/tools/approval-service/go.sum
+++ b/tools/approval-service/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github/v63 v63.0.0 h1:13xwK/wk9alSokujB9lJkuzdmQuVn2QCPeck76wR3nE=
+github.com/google/go-github/v63 v63.0.0/go.mod h1:IqbcrgUmIcEaioWrGYei/09o+ge5vhffGOcxrO0AfmA=
+github.com/google/go-github/v69 v69.1.0 h1:ljzwzEsHsc4qUqyHEJCNA1dMqvoTK3YX2NAaK6iprDg=
+github.com/google/go-github/v69 v69.1.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMMwGZa0Aehh1azM=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Created an implementation for the GitHub webhook. It is just a small wrapper around the go-github library.

Made some changes to the main function to use `errgroup` to run the `eventSources` concurrently. The `errgroup` library handles propagating cancellations that result from errors and is similar in functionality to waitgroups. In the event of an error from one of the `eventSources`, the `errgroup` will cancel the context which all goroutines in the group can react to appropriately.