### PR TITLE
[bot] Allow for non-PR events in docpaths

### DIFF
--- a/bot/internal/bot/docpaths.go
+++ b/bot/internal/bot/docpaths.go
@@ -34,6 +34,11 @@ type DocsRedirect struct {
 // assumed that there is a file called docs/config.json at the root of the
 // directory that lists redirects in the redirects field.
 func (b *Bot) CheckDocsPathsForMissingRedirects(ctx context.Context, teleportClonePath string) error {
+	// The event is not a pull request, so don't check PR files.
+	if b.c.Environment.Number == 0 {
+		return nil
+	}
+
 	if teleportClonePath == "" {
 		return trace.BadParameter("unable to load Teleport documentation config with an empty path")
 	}

--- a/bot/internal/bot/docpaths_test.go
+++ b/bot/internal/bot/docpaths_test.go
@@ -18,6 +18,7 @@ func TestCheckDocsPathsForMissingRedirects(t *testing.T) {
 		teleportClonePath string
 		docsConfig        string
 		errorSubstring    string
+		number            int
 	}{
 		{
 			description:       "valid clone path with no error",
@@ -33,6 +34,7 @@ func TestCheckDocsPathsForMissingRedirects(t *testing.T) {
       }
   ]
 }`,
+			number:         1,
 			errorSubstring: "",
 		},
 		{
@@ -43,13 +45,22 @@ func TestCheckDocsPathsForMissingRedirects(t *testing.T) {
   "variables": {},
   "redirects": []
 }`,
+			number:         1,
 			errorSubstring: "missing redirects for the following renamed or deleted pages: /database-access/get-started/",
 		},
 		{
 			description:       "invalid config file",
 			teleportClonePath: "/teleport",
 			docsConfig:        `This file is not JSON.`,
+			number:            1,
 			errorSubstring:    "docs/config.json: invalid character 'T' looking for beginning of value",
+		},
+		{
+			description:       "invalid config file with PR 0",
+			teleportClonePath: "/teleport",
+			docsConfig:        `This file is not JSON.`,
+			number:            0,
+			errorSubstring:    "",
 		},
 	}
 
@@ -67,7 +78,9 @@ func TestCheckDocsPathsForMissingRedirects(t *testing.T) {
 
 			b := &Bot{
 				c: &Config{
-					Environment: &env.Environment{},
+					Environment: &env.Environment{
+						Number: c.number,
+					},
 					GitHub: &fakeGithub{
 						files: []github.PullRequestFile{
 							{


### PR DESCRIPTION
The workflow currently fails if the event is not a pull request, since it attempts to list files for a PR with number 0 and receives a 404 from the GitHub API. Edit the workflow so it does not return an error if the event is not a PR.