### PR TITLE
Now supports multiple changelog entries in a PR

### DIFF
--- a/tools/changelog/changelog.go
+++ b/tools/changelog/changelog.go
@@ -83,7 +83,7 @@ func (c *changelogGenerator) generateChangelog(ctx context.Context, branch strin
 func (c *changelogGenerator) toChangelog(prs []github.ChangelogPR) (string, error) {
 	var clList []changelogInfo
 	for _, pr := range prs {
-		clList = append(clList, newChangelogInfoFromPR(pr))
+		clList = append(clList, newChangelogInfoFromPR(pr)...)
 	}
 
 	var buff bytes.Buffer
@@ -95,29 +95,47 @@ func (c *changelogGenerator) toChangelog(prs []github.ChangelogPR) (string, erro
 }
 
 // convertPRToChangelog will convert the list of PRs to a nicer format.
-func newChangelogInfoFromPR(pr github.ChangelogPR) changelogInfo {
-	found, clSummary := findChangelog(pr.Body)
+func newChangelogInfoFromPR(pr github.ChangelogPR) []changelogInfo {
+	found, summaries := findChangelogs(pr.Body)
 	if !found {
 		// Pull out title and indicate no changelog found
-		clSummary = fmt.Sprintf("NOCL: %s", pr.Title)
+		return []changelogInfo{
+			{
+				Summary: fmt.Sprintf("NOCL: %s", pr.Title),
+				Number:  pr.Number,
+				URL:     pr.URL,
+			},
+		}
 	}
-	return changelogInfo{
-		Summary: prettierSummary(clSummary),
-		Number:  pr.Number,
-		URL:     pr.URL,
+
+	cls := []changelogInfo{}
+	for _, clSummary := range summaries {
+		cls = append(cls, changelogInfo{
+			Summary: prettierSummary(clSummary),
+			Number:  pr.Number,
+			URL:     pr.URL,
+		})
 	}
+
+	return cls
 }
 
 // findChangelog will parse a body of a PR to find a changelog.
-func findChangelog(commentBody string) (found bool, summary string) {
+func findChangelogs(commentBody string) (found bool, summaries []string) {
 	// If a match is found then we should get a non empty slice
 	// 0 index will be the whole match including "changelog: *"
 	// 1 index will be the subgroup match which does not include "changelog: "
-	m := clPattern.FindStringSubmatch(commentBody)
-	if len(m) > 1 {
-		return true, m[1]
+	m := clPattern.FindAllStringSubmatch(commentBody, -1)
+	if len(m) < 1 {
+		return false, nil
 	}
-	return false, ""
+
+	sum := []string{}
+
+	for _, v := range m {
+		sum = append(sum, v[1])
+	}
+	return true, sum
 }
 
 func prettierSummary(cl string) string {

--- a/tools/changelog/testdata/expected-cl.md
+++ b/tools/changelog/testdata/expected-cl.md
@@ -1,3 +1,7 @@
+* Fixed broken `Download Metadata File` button from the SAML enrolling resource flow in the web UI. [#52276](https://github.com/gravitational/teleport/pull/52276)
+* Fixed broken `Refresh` button in the Access Monitoring reports page in the web UI. [#52276](https://github.com/gravitational/teleport/pull/52276)
+* Fixed broken `Download app.zip` menu item in the Integrations list dropdown menu for Microsoft Teams in the web UI. [#52276](https://github.com/gravitational/teleport/pull/52276)
+* Fixed `Unexpected end of JSON input` error in an otherwise successful web API call. [#52276](https://github.com/gravitational/teleport/pull/52276)
 * Add audit event field describing if the "MFA for admin actions" requirement changed. [#43541](https://github.com/gravitational/teleport/pull/43541)
 * Display errors in the web UI console for SSH and Kubernetes sessions. [#43485](https://github.com/gravitational/teleport/pull/43485)
 * Update go-retryablehttp to v0.7.7 (fixes CVE-2024-6104). [#43474](https://github.com/gravitational/teleport/pull/43474)

--- a/tools/changelog/testdata/listed-prs.json
+++ b/tools/changelog/testdata/listed-prs.json
@@ -1,5 +1,11 @@
 [
     {
+        "body": "Backport #52154 to branch/v17\r\n\r\nchangelog: Fixed broken `Download Metadata File` button from the SAML enrolling resource flow in the web UI.\r\nchangelog: Fixed broken `Refresh` button in the Access Monitoring reports page in the web UI.\r\nchangelog: Fixed broken `Download app.zip` menu item in the Integrations list dropdown menu for Microsoft Teams in the web UI.\r\nchangelog: Fixed `Unexpected end of JSON input` error in an otherwise successful web API call.\r\n",
+        "number": 52276,
+        "title": "[v17] Web: Fixes handling native fetch response that can result in unexpected errors",
+        "url": "https://github.com/gravitational/teleport/pull/52276"
+    },
+    {
         "body": "Backport #43245 to branch/v16\r\n\r\nchangelog: Add audit event field describing if the \"MFA for admin actions\" requirement changed\r\n",
         "number": 43541,
         "title": "[v16] audit when the MFA for admin actions requirement is changed",


### PR DESCRIPTION
The original changelog script supported multiple changelog entries present but when refactoring the script to Go tooling this feature was forgotten.

The changelog tool should now support multiple changelog entries present in the pull request body.

For example, given a PR body:
   This is a PR
   changelog: First entry
   changelog: Second entry
   changelog: Third entry

It should present in the CHANGELOG generated
   * First entry [1](link to same PR)
   * Second entry [1](link to same PR)
   * Third entry [1](link to same PR)