### PR TITLE
[bot] Ignore includes in docpaths

### DIFF
--- a/bot/internal/bot/docpaths.go
+++ b/bot/internal/bot/docpaths.go
@@ -97,6 +97,11 @@ func toURLPath(p string) string {
 	return redir + "/"
 }
 
+// includeSegment is a file path segment that indicates the presence of
+// includes, which we don't check for redirects if a PR renames or deletes them.
+// Since PR filenames come from the GitHub API, paths include forward slashes.
+const includeSegment = "/includes/"
+
 // missingRedirectSources checks renamed or deleted docs pages in files to
 // ensure that there is a corresponding redirect source in conf. For any missing
 // redirects, it lists redirect sources that should be in conf.
@@ -109,6 +114,11 @@ func missingRedirectSources(conf []DocsRedirect, files github.PullRequestFiles) 
 	res := []string{}
 	for _, f := range files {
 		if !strings.HasPrefix(f.Name, docsPrefix) {
+			continue
+		}
+
+		// Skip partials
+		if strings.Contains(f.Name, includeSegment) {
 			continue
 		}
 

--- a/bot/internal/bot/docpaths_test.go
+++ b/bot/internal/bot/docpaths_test.go
@@ -257,6 +257,34 @@ func TestMissingRedirectSources(t *testing.T) {
 			},
 			expected: []string{},
 		},
+		{
+			description: "renamed 3rd-level includes path with no redirects",
+			files: github.PullRequestFiles{
+				{
+					Name:         "docs/pages/includes/databases/mysql-certs.mdx",
+					Additions:    0,
+					Deletions:    0,
+					Status:       "renamed",
+					PreviousName: "docs/pages/includes/databases/mysql.mdx",
+				},
+			},
+			redirects: []DocsRedirect{},
+			expected:  []string{},
+		},
+		{
+			description: "renamed 4rd-level includes path with no redirects",
+			files: github.PullRequestFiles{
+				{
+					Name:         "docs/pages/connect-your-client/includes/mysql-certs.mdx",
+					Additions:    0,
+					Deletions:    0,
+					Status:       "renamed",
+					PreviousName: "docs/pages/connect-your-client/includes/mysql.mdx",
+				},
+			},
+			redirects: []DocsRedirect{},
+			expected:  []string{},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
The docpaths workflow currently blocks pull requests that rename or delete partials, which is not intended: the docs engine does not generate routes for partials.

This change skips redirect checking for any file path that includes the `/includes/` segment. This follows the logic of the docs engine, which checks whether a page path includes the `/includes/` segment and, if not, moves it into the directory that Docusaurus uses to generate page routes.