### PR TITLE
Update dependency-review action

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@5bbc3ba658137598168acb2ab73b21c432dd411b # v4.2.5
+        uses: actions/dependency-review-action@72eb03d02c7872a771aacd928f3123ac62ad6d3a # v4.3.3
         with:
           fail-on-severity: ${{ inputs.fail-on-severity }}
           # NOTE: List shouldn't end with comma


### PR DESCRIPTION
We want at least v4.3.3 in order to get the fix from https://github.com/actions/dependency-review-action/pull/767 that prevents large summaries from failing the job.