### PR TITLE
dependency review: disable comment summary

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -101,6 +101,6 @@ jobs:
             ${{ inputs.allow-additional-licenses }}
           allow-ghsas: ${{ inputs.allow-ghsas }}
           allow-dependencies-licenses: ${{ inputs.allow-dependencies-licenses != '' && format('pkg:golang/github.com/gravitational/teleport, pkg:golang/github.com/gravitational/teleport/api, {0}', inputs.allow-dependencies-licenses) || 'pkg:golang/github.com/gravitational/teleport, pkg:golang/github.com/gravitational/teleport/api'}}
-          comment-summary-in-pr: on-failure
+          comment-summary-in-pr: never
           base-ref: ${{ inputs.base-ref || github.event.pull_request.base.sha || github.event.repository.default_branch }}
           head-ref: ${{ inputs.head-ref || github.event.pull_request.head.sha || github.ref }}


### PR DESCRIPTION
The job will fail if the comment it tries to post to the PR is too large. This is fixed in newer versions of the action, but there are other breaking changes to navigate if we want to update so the quick fix for now is to disable comment summaries.