### PR TITLE
Fix tflint implementation

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -48,4 +48,4 @@ jobs:
         run: tflint --init
 
       - name: Run TFLint
-        run: tflint -f compact
+        run: tflint -f compact --recursive

--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -2,6 +2,10 @@ name: Lint (Terraform)
 
 on:
   workflow_call:
+    inputs:
+      tflint_config_path:
+        required: false
+        type: string
 
 # TODO: Add job for `terraform validate`
 jobs:
@@ -37,6 +41,10 @@ jobs:
         with:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('.tflint.hcl') }}
+
+      - name: Set config path
+        if: inputs.tflint_config_path != ''
+        run: echo "TFLINT_CONFIG_FILE=${{ inputs.tflint_config_path }}" >> $GITHUB_ENV
 
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@19a52fbac37dacb22a09518e4ef6ee234f2d4987 # v4.0.0


### PR DESCRIPTION
`tflint` does not run recursively by default, so this is only executing against the repo root, which often does nothing. 