### PR TITLE
gha(path-filter) fix quotes

### DIFF
--- a/.github/workflows/csv-lint.yaml
+++ b/.github/workflows/csv-lint.yaml
@@ -24,7 +24,7 @@ jobs:
           list-files: shell
           filters: |
             csv:
-              - **/*.csv
+              - '**/*.csv'
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/json-lint.yaml
+++ b/.github/workflows/json-lint.yaml
@@ -24,7 +24,7 @@ jobs:
           list-files: shell
           filters: |
             json:
-              - **/*.json
+              - '**/*.json'
 
       - name: jsonlint
         if: steps.changed-files.outputs.json == 'true'


### PR DESCRIPTION
Add quotes around `*` to fix failures like:
```
Error: unidentified alias "*/*.csv" (2:13)

 1 | csv:
 2 |   - **/*.csv
-----------------^
```