### PR TITLE
changelog: Do not add PR links for enterprise changelogs

### DIFF
--- a/tools/changelog/changelog_test.go
+++ b/tools/changelog/changelog_test.go
@@ -36,15 +36,36 @@ func decodeTestData(t *testing.T, data []byte) []github.ChangelogPR {
 }
 
 func TestToChangelog(t *testing.T) {
-	prsText, err := os.ReadFile(filepath.Join("testdata", "listed-prs.json"))
-	require.NoError(t, err)
-	expectedCL, err := os.ReadFile(filepath.Join("testdata", "expected-cl.md"))
-	require.NoError(t, err)
+	testCases := []struct {
+		name           string
+		expectedFile   string
+		excludePRLinks bool
+	}{
+		{
+			name:           "include-links",
+			expectedFile:   "expected-cl.md",
+			excludePRLinks: false,
+		},
+		{
+			name:           "exclude-links",
+			expectedFile:   "expected-cl-no-links.md",
+			excludePRLinks: true,
+		},
+	}
 
-	prs := decodeTestData(t, prsText)
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			prsText, err := os.ReadFile(filepath.Join("testdata", "listed-prs.json"))
+			require.NoError(t, err)
+			expectedCL, err := os.ReadFile(filepath.Join("testdata", tt.expectedFile))
+			require.NoError(t, err)
 
-	gen := &changelogGenerator{}
-	got, err := gen.toChangelog(prs)
-	assert.NoError(t, err)
-	assert.Equal(t, string(expectedCL), got)
+			prs := decodeTestData(t, prsText)
+
+			gen := &changelogGenerator{excludePRLinks: tt.excludePRLinks}
+			got, err := gen.toChangelog(prs)
+			assert.NoError(t, err)
+			assert.Equal(t, string(expectedCL), got)
+		})
+	}
 }

--- a/tools/changelog/main.go
+++ b/tools/changelog/main.go
@@ -94,8 +94,9 @@ func main() {
 		repo:     "teleport",
 	}
 	entCLGen := &changelogGenerator{
-		ghclient: cl,
-		repo:     "teleport.e",
+		ghclient:       cl,
+		repo:           "teleport.e",
+		excludePRLinks: true,
 	}
 	ossCL, err := ossCLGen.generateChangelog(ctx, branch, timeLastRelease, github.SearchTimeNow)
 	if err != nil {

--- a/tools/changelog/testdata/expected-cl-no-links.md
+++ b/tools/changelog/testdata/expected-cl-no-links.md
@@ -1,0 +1,18 @@
+* Add audit event field describing if the "MFA for admin actions" requirement changed.
+* Display errors in the web UI console for SSH and Kubernetes sessions.
+* Update go-retryablehttp to v0.7.7 (fixes CVE-2024-6104).
+* Fixes an issue preventing accurate inventory reporting of the updater after it is removed.
+* Fix input searching logic for Connect's access request listing view.
+* Debug setting available for event-handler via configuration or FDFWD_DEBUG environment variable.
+* Fix Headless auth for sso users, including when local auth is disabled.
+* Add configuration for custom CAs in the event-handler helm chart.
+* VNet panel in Teleport Connect now lists custom DNS zones and DNS zones from leaf clusters.
+* Fixed an issue with Database Access Controls preventing users from making additional database connections depending on their permissions.
+* Fixed bug that caused gRPC connections to be disconnected when their certificate expired even though DisconnectCertExpiry was false.
+* Fixed Connect My Computer in Teleport Connect failing with "bind: invalid argument".
+* Fix a bug where a Teleport instance running only Jamf or Discovery service would never have a healthy  `/readyz` endpoint.
+* Added a missing `[Install]` section to the `teleport-acm` systemd unit file as used by Teleport AMIs.
+* Patched timing variability in curve25519-dalek.
+* Fix setting request reason for automatic ssh access requests.
+* Improved log rotation logic in Teleport Connect; now the non-numbered files always contain recent logs.
+* Adds `tctl desktop bootstrap` for bootstrapping AD environments to work with Desktop Access.


### PR DESCRIPTION
Do not link to PRs for enterprise changelogs as that is a private repo
and the links will not work for most. Given that the changelog is
published in the OSS repo, it does not make sense to include private
links.
