### PR TITLE
Honor approvals from people on `codeReviewersOmit` list

### DIFF
--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -462,7 +462,7 @@ func (r *Assignments) checkInternalReleaseReviews(reviews []github.Review) error
 // checkInternalReviews checks whether review requirements are satisfied
 // for a PR authored by an internal employee
 func (r *Assignments) checkInternalReviews(e *env.Environment, changes env.Changes, reviews []github.Review, files []github.PullRequestFile) error {
-	setA, setB := getReviewerSets(e.Author, r.repoReviewers(e), r.c.CodeReviewersOmit)
+	setA, setB := getReviewerSets(e.Author, r.repoReviewers(e), map[string]bool{})
 
 	// If this PR touches docs, then approvals from docs reviewers also count.
 	// Add them to set B, as docs reviewers are not required so long as we get


### PR DESCRIPTION
Currently if a person is on `codeReviewersOmit` list their approval no longer satisfies the "internal reviewers" check. 

My understanding is that this is incorrect, as `codeReviewersOmit` was meant to reduce the workload of busy people while keeping their permissions intact.

This PR fixes that behaviour.