### PR TITLE
Make tflint failure severity configurable

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -6,6 +6,10 @@ on:
       tflint_config_path:
         required: false
         type: string
+      tflint_minimum_failure_severity:
+        required: false
+        type: string
+        default: warning
 
 # TODO: Add job for `terraform validate`
 jobs:
@@ -56,4 +60,4 @@ jobs:
         run: tflint --init
 
       - name: Run TFLint
-        run: tflint -f compact --recursive
+        run: tflint -f compact --recursive --minimum-failure-severity=${{ inputs.tflint_minimum_failure_severity }}


### PR DESCRIPTION
https://github.com/gravitational/shared-workflows/pull/343 fixed this check recently. Some repos have lots of warnings ([cloud-terraform](https://github.com/gravitational/cloud-terraform/actions/runs/14132000344/job/39594447742?pr=6318)) and may wish to ignore them for the time being. Make the failure severity configurable.