### PR TITLE
Expose force option in tflint workflow

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
         default: warning
+      tflint_force:
+        required: false
+        type: string
+        default: false
 
 # TODO: Add job for `terraform validate`
 jobs:
@@ -60,4 +64,4 @@ jobs:
         run: tflint --init
 
       - name: Run TFLint
-        run: tflint -f compact --recursive --minimum-failure-severity=${{ inputs.tflint_minimum_failure_severity }}
+        run: tflint -f compact --recursive --minimum-failure-severity=${{ inputs.tflint_minimum_failure_severity }} --force=${{ inputs.tflint_force }}


### PR DESCRIPTION
Teleport repo has lots of [failures](https://github.com/gravitational/teleport/actions/runs/14179688579/job/39722703386#step:8:162), some at the error level. Instead of chasing them all right now enable forcing a 0 exit status. This is necessary because the config file `force` option doesn't work with the `--recursive` flag.