### PR TITLE
Revert "Expose force option in tflint workflow"

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -10,10 +10,6 @@ on:
         required: false
         type: string
         default: warning
-      tflint_force:
-        required: false
-        type: string
-        default: false
 
 # TODO: Add job for `terraform validate`
 jobs:
@@ -64,4 +60,4 @@ jobs:
         run: tflint --init
 
       - name: Run TFLint
-        run: tflint -f compact --recursive --minimum-failure-severity=${{ inputs.tflint_minimum_failure_severity }} --force=${{ inputs.tflint_force }}
+        run: tflint -f compact --recursive --minimum-failure-severity=${{ inputs.tflint_minimum_failure_severity }}


### PR DESCRIPTION
Reverts gravitational/shared-workflows#354

`force` cli option is not consistent with config option.