### PR TITLE
Exclude testdata proto directory for operator

### DIFF
--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -280,6 +280,7 @@ func skipFileForSizeCheck(name string) bool {
 		strings.HasSuffix(name, ".snap") ||
 		strings.Contains(name, "webassets/") ||
 		strings.Contains(name, "vendor/") ||
+		strings.Contains(name, "integrations/operator/crdgen/testdata/") ||
 		isCRDRegex.MatchString(name)
 }
 


### PR DESCRIPTION
This directory holds copied protos for the Teleport Kubernetes Operator, and can cause diffs of thousands of lines when new resources are being introduced. 