### PR TITLE
dependency review: add license for protobuf.js

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -75,6 +75,7 @@ jobs:
             BSD-2-Clause-FreeBSD,
             BSD-2-Clause,
             BSD-3-Clause AND BSD-3-Clause-Clear,
+            BSD-3-Clause AND LicenseRef-scancode-protobuf,
             BSD-3-Clause,
             CC-BY-3.0,
             CC-BY-4.0,


### PR DESCRIPTION
The dependency review tool now reports protobuf.js's license as `BSD-3-Clause AND LicenseRef-scancode-protobuf`. I'm not entirely sure why, it might be due to the license being a custom one? https://github.com/protobufjs/protobuf.js/blob/master/LICENSE

protobuf.js is now a dependency of the tool `@redocly/cli` we use in Identity Security to stitch OpenAPI spec files together. Upgrading to the latest version resulted in this dependency error. https://github.com/gravitational/access-graph/pull/1553