### PR TITLE
Update CSV linter to ignore removed files

### DIFF
--- a/.github/workflows/csv-lint.yaml
+++ b/.github/workflows/csv-lint.yaml
@@ -25,7 +25,7 @@ jobs:
           list-files: shell
           filters: |
             csv:
-              - '**/*.csv'
+              - added|modified: '**/*.csv'
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Currently the action considers removed CSV files as "changed" too which results in the action failing when trying to lint a removed file. This change should make the action only consider added or modified files. The syntax used is documented here: https://github.com/dorny/paths-filter?tab=readme-ov-file#advanced-options.