### PR TITLE
Add codeowners for /web dep updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @gravitational/dev-eng-leads
+
+# owners for dependency updates in /web packages
+**/package.json @avatus @gzdunek @ravicious


### PR DESCRIPTION
is this the right `CODEOWNERS` file that affects the teleport and `e` repos? I couldn't find them in the repo themselves so I figured it would be here, but honestly I don't understand how its supposed to work if this current file is just "all files require review from code owners". if anything this looks specific to this repo only and _not_ the teleport repos. Happy for guidance

With the [dependabot.yaml
deprecation](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) the suggested change is to add reviewers to the CODEOWNERS file directly. Unfortunately this doesn't seem to give us the granularity to select "only dependabot PRs" and so I think the next best thing is just assign us to any PR that updates the package.json files (which is usually just dependabot).

very open to alternative suggestions, and also we can maybe keep this open and add the other configs for the go side of things as well