### PR TITLE
Add webasset bundle analysis to the workflows bot

### DIFF
--- a/bot/internal/bot/bot.go
+++ b/bot/internal/bot/bot.go
@@ -23,10 +23,11 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/shared-workflows/bot/internal/env"
 	"github.com/gravitational/shared-workflows/bot/internal/github"
 	"github.com/gravitational/shared-workflows/bot/internal/review"
-	"github.com/gravitational/trace"
 )
 
 // isCRDRegex matches Teleport operator CRD file paths.
@@ -67,6 +68,9 @@ type Client interface {
 
 	// CreateComment will leave a comment on an Issue or Pull Request.
 	CreateComment(ctx context.Context, organization string, repository string, number int, comment string) error
+
+	// EditComment will update an existing comment on an Issue or Pull Request.
+	EditComment(ctx context.Context, organization string, repository string, commentID int64, comment string) error
 
 	// ListComments will list all comments on an Issue or Pull Request.
 	ListComments(ctx context.Context, organization string, repository string, number int) ([]github.Comment, error)

--- a/bot/internal/bot/bot_test.go
+++ b/bot/internal/bot/bot_test.go
@@ -519,6 +519,16 @@ func (f *fakeGithub) CreateComment(ctx context.Context, organization string, rep
 	return nil
 }
 
+func (f *fakeGithub) EditComment(ctx context.Context, organization string, repository string, commentID int64, comment string) error {
+	for i, c := range f.comments {
+		if c.ID == commentID {
+			f.comments[i].Body = comment
+			return nil
+		}
+	}
+	return nil
+}
+
 func (f *fakeGithub) ListComments(ctx context.Context, organization string, repository string, number int) ([]github.Comment, error) {
 	return f.comments, nil
 }

--- a/bot/internal/bot/webassets.go
+++ b/bot/internal/bot/webassets.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bot
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+	"github.com/gravitational/shared-workflows/bot/internal/webassets"
+)
+
+func (b *Bot) CompareWebAssetsStats(ctx context.Context, statsPaths string) error {
+	beforePath, afterPath, err := parseStatsPaths(statsPaths)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	before, err := webassets.LoadStats(beforePath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	after, err := webassets.LoadStats(afterPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	comparison, err := webassets.Compare(before, after)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return b.reconcileComment(ctx, comparison)
+}
+
+func (b *Bot) reconcileComment(ctx context.Context, body string) error {
+	comments, err := b.c.GitHub.ListComments(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		b.c.Environment.Number,
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	existingCommentIndex := slices.IndexFunc(comments, func(c github.Comment) bool {
+		return webassets.IsBotComment(c.Body)
+	})
+
+	if existingCommentIndex >= 0 {
+		comment := comments[existingCommentIndex]
+
+		return trace.Wrap(b.c.GitHub.EditComment(ctx,
+			b.c.Environment.Organization,
+			b.c.Environment.Repository,
+			comment.ID,
+			body,
+		))
+	}
+
+	return trace.Wrap(b.c.GitHub.CreateComment(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		b.c.Environment.Number,
+		body,
+	))
+}
+
+func parseStatsPaths(statsPaths string) (beforeStatsPath, afterStatsPath string, err error) {
+	split := strings.Split(statsPaths, ",")
+	if len(split) != 2 {
+		return "", "", trace.BadParameter("expected two paths separated by a comma, got %q", statsPaths)
+	}
+
+	beforeStatsPath = strings.TrimSpace(split[0])
+	afterStatsPath = strings.TrimSpace(split[1])
+
+	if beforeStatsPath == "" || afterStatsPath == "" {
+		return "", "", trace.BadParameter("both paths must be non-empty")
+	}
+
+	return beforeStatsPath, afterStatsPath, nil
+}

--- a/bot/internal/bot/webassets_test.go
+++ b/bot/internal/bot/webassets_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/shared-workflows/bot/internal/env"
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+)
+
+func TestReconcileComment(t *testing.T) {
+	tests := []struct {
+		desc             string
+		existingComments []github.Comment
+		body             string
+		expectCreate     bool
+		expectEditID     int64
+	}{
+		{
+			desc:             "no existing comments - should create",
+			existingComments: []github.Comment{},
+			body:             "# 📦 Bundle Size Report\n\nTest report content",
+			expectCreate:     true,
+		},
+		{
+			desc: "existing bot comment - should update",
+			existingComments: []github.Comment{
+				{
+					ID:   123,
+					Body: "# 📦 Bundle Size Report\n\nOld report content",
+				},
+			},
+			body:         "# 📦 Bundle Size Report\n\nNew report content",
+			expectCreate: false,
+			expectEditID: 123,
+		},
+		{
+			desc: "existing non-bot comments - should create",
+			existingComments: []github.Comment{
+				{
+					ID:   456,
+					Body: "This is a regular comment",
+				},
+				{
+					ID:   789,
+					Body: "Another regular comment",
+				},
+			},
+			body:         "# 📦 Bundle Size Report\n\nTest report content",
+			expectCreate: true,
+		},
+		{
+			desc: "multiple comments with bot comment - should update bot comment",
+			existingComments: []github.Comment{
+				{
+					ID:   100,
+					Body: "Regular comment before",
+				},
+				{
+					ID:   200,
+					Body: "# 📦 Bundle Size Report\n\nExisting bot report",
+				},
+				{
+					ID:   300,
+					Body: "Regular comment after",
+				},
+			},
+			body:         "# 📦 Bundle Size Report\n\nUpdated bot report",
+			expectCreate: false,
+			expectEditID: 200,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gh := &fakeGithub{
+				comments: test.existingComments,
+			}
+
+			bot := Bot{
+				c: &Config{
+					GitHub: gh,
+					Environment: &env.Environment{
+						Organization: "gravitational",
+						Repository:   "teleport",
+						Number:       42,
+					},
+				},
+			}
+
+			err := bot.reconcileComment(context.Background(), test.body)
+
+			require.NoError(t, err)
+
+			if test.expectCreate {
+				require.Len(t, gh.comments, len(test.existingComments)+1)
+
+				lastComment := gh.comments[len(gh.comments)-1]
+
+				require.Equal(t, test.body, lastComment.Body)
+			} else {
+				require.Len(t, gh.comments, len(test.existingComments))
+
+				for _, comment := range gh.comments {
+					if comment.ID == test.expectEditID {
+						require.Equal(t, test.body, comment.Body)
+
+						break
+					}
+				}
+			}
+		})
+	}
+}

--- a/bot/internal/github/github.go
+++ b/bot/internal/github/github.go
@@ -606,9 +606,25 @@ func (c *Client) CreateComment(ctx context.Context, organization string, reposit
 	return nil
 }
 
+// EditComment will edit an existing comment on an Issue or Pull Request.
+func (c *Client) EditComment(ctx context.Context, organization string, repository string, id int64, comment string) error {
+	_, _, err := c.client.Issues.EditComment(ctx,
+		organization,
+		repository,
+		id,
+		&go_github.IssueComment{
+			Body: &comment,
+		})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
 // Comment represents an "issue comment" on a GitHub issue or pull request.
 // This does not include comments that are part of reviews.
 type Comment struct {
+	ID     int64  // the ID of the comment
 	Author string // the GitHub username of the author
 	Body   string // the text of the comment
 
@@ -640,6 +656,7 @@ func (c *Client) ListComments(ctx context.Context, organization string, reposito
 
 		for _, comment := range comments {
 			result = append(result, Comment{
+				ID:        comment.GetID(),
 				Body:      comment.GetBody(),
 				Author:    comment.GetUser().GetLogin(),
 				CreatedAt: comment.GetCreatedAt(),

--- a/bot/internal/webassets/analyze.go
+++ b/bot/internal/webassets/analyze.go
@@ -1,0 +1,158 @@
+package webassets
+
+import (
+	"math"
+	"sort"
+)
+
+type moduleAnalysis struct {
+	newModules          []moduleChange
+	increasedModules    []moduleChange
+	allModules          []moduleChange
+	removedModulesCount int
+}
+
+type moduleChange struct {
+	name     string
+	size     int64
+	gzipSize int64
+	change   sizeChange
+	isNew    bool
+}
+
+func analyzeModules(before, after Stats) moduleAnalysis {
+	result := moduleAnalysis{}
+
+	for moduleName, afterSize := range after.ModuleSizes {
+		beforeSize, existedBefore := before.ModuleSizes[moduleName]
+		afterGzipSize := after.ModuleGzipSizes[moduleName]
+
+		var change sizeChange
+		if existedBefore {
+			change = calculateSizeChange(beforeSize, afterSize)
+		} else {
+			change = calculateSizeChange(0, afterSize)
+		}
+
+		mc := moduleChange{
+			name:     moduleName,
+			size:     afterSize,
+			gzipSize: afterGzipSize,
+			change:   change,
+			isNew:    !existedBefore,
+		}
+
+		if !existedBefore {
+			result.newModules = append(result.newModules, mc)
+		} else if change.diff > significantIncreaseThreshold {
+			result.increasedModules = append(result.increasedModules, mc)
+		}
+
+		result.allModules = append(result.allModules, mc)
+	}
+
+	for moduleName := range before.ModuleSizes {
+		if _, exists := after.ModuleSizes[moduleName]; !exists {
+			result.removedModulesCount++
+		}
+	}
+
+	sort.Slice(result.newModules, func(i, j int) bool {
+		return result.newModules[i].size > result.newModules[j].size
+	})
+
+	sort.Slice(result.increasedModules, func(i, j int) bool {
+		return result.increasedModules[i].change.diff > result.increasedModules[j].change.diff
+	})
+
+	sort.Slice(result.allModules, func(i, j int) bool {
+		return result.allModules[i].size > result.allModules[j].size
+	})
+
+	return result
+}
+
+type fileAnalysis struct {
+	newFiles          []moduleChange
+	removedFilesCount int
+}
+
+func analyzeFiles(before, after Stats) fileAnalysis {
+	result := fileAnalysis{}
+
+	for fileName, afterSize := range after.FileSizes {
+		if _, exists := before.FileSizes[fileName]; exists {
+			continue
+		}
+
+		result.newFiles = append(result.newFiles, moduleChange{
+			name:     fileName,
+			size:     afterSize,
+			gzipSize: after.FileGzipSizes[fileName],
+			isNew:    true,
+			change:   calculateSizeChange(0, afterSize),
+		})
+	}
+
+	for fileName := range before.FileSizes {
+		if _, exists := after.FileSizes[fileName]; !exists {
+			result.removedFilesCount++
+		}
+	}
+
+	sort.Slice(result.newFiles, func(i, j int) bool {
+		return result.newFiles[i].size > result.newFiles[j].size
+	})
+
+	return result
+}
+
+type bundleAnalysis struct {
+	changedBundles []bundleChange
+	newBundles     []bundleChange
+}
+
+type bundleChange struct {
+	name     string
+	size     int64
+	gzipSize int64
+	change   sizeChange
+}
+
+func analyzeBundles(before, after Stats) bundleAnalysis {
+	result := bundleAnalysis{}
+
+	for bundleName, afterSize := range after.BundleSizes {
+		beforeSize, existedBefore := before.BundleSizes[bundleName]
+
+		change := bundleChange{
+			name:     bundleName,
+			size:     afterSize,
+			gzipSize: after.BundleGzipSizes[bundleName],
+		}
+
+		if !existedBefore {
+			change.change = calculateSizeChange(0, afterSize)
+
+			result.newBundles = append(result.newBundles, change)
+
+			continue
+		}
+
+		change.change = calculateSizeChange(beforeSize, afterSize)
+
+		if change.change.diff != 0 {
+			result.changedBundles = append(result.changedBundles, change)
+		}
+	}
+
+	sort.Slice(result.changedBundles, func(i, j int) bool {
+		return math.Abs(float64(result.changedBundles[i].change.diff)) > math.Abs(float64(result.changedBundles[j].change.diff))
+	})
+
+	sort.Slice(result.newBundles, func(i, j int) bool {
+		return result.newBundles[i].size > result.newBundles[j].size
+	})
+
+	return result
+}

--- a/bot/internal/webassets/analyze_test.go
+++ b/bot/internal/webassets/analyze_test.go
@@ -1,0 +1,345 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webassets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeModules(t *testing.T) {
+	tests := []struct {
+		name                     string
+		before                   Stats
+		after                    Stats
+		expectedNewModules       []string
+		expectedIncreasedModules []string
+		expectedRemovedCount     int
+	}{
+		{
+			name: "new modules detected",
+			before: Stats{
+				ModuleSizes: map[string]int64{
+					"react": 150000,
+				},
+				ModuleGzipSizes: map[string]int64{
+					"react": 45000,
+				},
+			},
+			after: Stats{
+				ModuleSizes: map[string]int64{
+					"react":     150000,
+					"react-dom": 120000,
+					"lodash":    80000,
+				},
+				ModuleGzipSizes: map[string]int64{
+					"react":     45000,
+					"react-dom": 36000,
+					"lodash":    24000,
+				},
+			},
+			expectedNewModules:       []string{"react-dom", "lodash"},
+			expectedIncreasedModules: []string{},
+			expectedRemovedCount:     0,
+		},
+		{
+			name: "increased modules detected",
+			before: Stats{
+				ModuleSizes: map[string]int64{
+					"react":     150000,
+					"react-dom": 100000,
+				},
+				ModuleGzipSizes: map[string]int64{
+					"react":     45000,
+					"react-dom": 30000,
+				},
+			},
+			after: Stats{
+				ModuleSizes: map[string]int64{
+					"react":     150000,
+					"react-dom": 110000, // 10KB increase, over threshold
+				},
+				ModuleGzipSizes: map[string]int64{
+					"react":     45000,
+					"react-dom": 33000,
+				},
+			},
+			expectedNewModules:       []string{},
+			expectedIncreasedModules: []string{"react-dom"},
+			expectedRemovedCount:     0,
+		},
+		{
+			name: "removed modules detected",
+			before: Stats{
+				ModuleSizes: map[string]int64{
+					"react":     150000,
+					"react-dom": 120000,
+					"lodash":    80000,
+				},
+				ModuleGzipSizes: map[string]int64{
+					"react":     45000,
+					"react-dom": 36000,
+					"lodash":    24000,
+				},
+			},
+			after: Stats{
+				ModuleSizes: map[string]int64{
+					"react": 150000,
+				},
+				ModuleGzipSizes: map[string]int64{
+					"react": 45000,
+				},
+			},
+			expectedNewModules:       []string{},
+			expectedIncreasedModules: []string{},
+			expectedRemovedCount:     2,
+		},
+		{
+			name: "small increases ignored",
+			before: Stats{
+				ModuleSizes: map[string]int64{
+					"react": 150000,
+				},
+				ModuleGzipSizes: map[string]int64{
+					"react": 45000,
+				},
+			},
+			after: Stats{
+				ModuleSizes: map[string]int64{
+					"react": 151000, // Only 1KB increase, below threshold
+				},
+				ModuleGzipSizes: map[string]int64{
+					"react": 45300,
+				},
+			},
+			expectedNewModules:       []string{},
+			expectedIncreasedModules: []string{},
+			expectedRemovedCount:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := analyzeModules(tt.before, tt.after)
+
+			newModuleNames := make([]string, len(result.newModules))
+			for i, m := range result.newModules {
+				newModuleNames[i] = m.name
+			}
+
+			require.ElementsMatch(t, tt.expectedNewModules, newModuleNames)
+
+			increasedModuleNames := make([]string, len(result.increasedModules))
+			for i, m := range result.increasedModules {
+				increasedModuleNames[i] = m.name
+			}
+
+			require.ElementsMatch(t, tt.expectedIncreasedModules, increasedModuleNames)
+
+			require.Equal(t, tt.expectedRemovedCount, result.removedModulesCount)
+
+			for i := 1; i < len(result.allModules); i++ {
+				require.GreaterOrEqual(t, result.allModules[i-1].size, result.allModules[i].size)
+			}
+		})
+	}
+}
+
+func TestAnalyzeFiles(t *testing.T) {
+	tests := []struct {
+		name                 string
+		before               Stats
+		after                Stats
+		expectedNewFiles     []string
+		expectedRemovedCount int
+	}{
+		{
+			name: "new files detected",
+			before: Stats{
+				FileSizes: map[string]int64{
+					"app.js": 50000,
+				},
+				FileGzipSizes: map[string]int64{
+					"app.js": 15000,
+				},
+			},
+			after: Stats{
+				FileSizes: map[string]int64{
+					"app.js":     50000,
+					"vendor.js":  100000,
+					"styles.css": 25000,
+				},
+				FileGzipSizes: map[string]int64{
+					"app.js":     15000,
+					"vendor.js":  30000,
+					"styles.css": 8000,
+				},
+			},
+			expectedNewFiles:     []string{"vendor.js", "styles.css"},
+			expectedRemovedCount: 0,
+		},
+		{
+			name: "removed files detected",
+			before: Stats{
+				FileSizes: map[string]int64{
+					"app.js":     50000,
+					"vendor.js":  100000,
+					"styles.css": 25000,
+				},
+				FileGzipSizes: map[string]int64{
+					"app.js":     15000,
+					"vendor.js":  30000,
+					"styles.css": 8000,
+				},
+			},
+			after: Stats{
+				FileSizes: map[string]int64{
+					"app.js": 50000,
+				},
+				FileGzipSizes: map[string]int64{
+					"app.js": 15000,
+				},
+			},
+			expectedNewFiles:     []string{},
+			expectedRemovedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := analyzeFiles(tt.before, tt.after)
+
+			newFileNames := make([]string, len(result.newFiles))
+			for i, f := range result.newFiles {
+				newFileNames[i] = f.name
+			}
+
+			require.ElementsMatch(t, tt.expectedNewFiles, newFileNames)
+
+			require.Equal(t, tt.expectedRemovedCount, result.removedFilesCount)
+
+			for i := 1; i < len(result.newFiles); i++ {
+				require.GreaterOrEqual(t, result.newFiles[i-1].size, result.newFiles[i].size)
+			}
+		})
+	}
+}
+
+func TestAnalyzeBundles(t *testing.T) {
+	tests := []struct {
+		name                   string
+		before                 Stats
+		after                  Stats
+		expectedNewBundles     []string
+		expectedChangedBundles []string
+	}{
+		{
+			name: "new bundles detected",
+			before: Stats{
+				BundleSizes: map[string]int64{
+					"main.js": 100000,
+				},
+				BundleGzipSizes: map[string]int64{
+					"main.js": 30000,
+				},
+			},
+			after: Stats{
+				BundleSizes: map[string]int64{
+					"main.js":   100000,
+					"vendor.js": 200000,
+				},
+				BundleGzipSizes: map[string]int64{
+					"main.js":   30000,
+					"vendor.js": 60000,
+				},
+			},
+			expectedNewBundles:     []string{"vendor.js"},
+			expectedChangedBundles: []string{},
+		},
+		{
+			name: "changed bundles detected",
+			before: Stats{
+				BundleSizes: map[string]int64{
+					"main.js":   100000,
+					"vendor.js": 200000,
+				},
+				BundleGzipSizes: map[string]int64{
+					"main.js":   30000,
+					"vendor.js": 60000,
+				},
+			},
+			after: Stats{
+				BundleSizes: map[string]int64{
+					"main.js":   110000, // increased
+					"vendor.js": 190000, // decreased
+				},
+				BundleGzipSizes: map[string]int64{
+					"main.js":   33000,
+					"vendor.js": 57000,
+				},
+			},
+			expectedNewBundles:     []string{},
+			expectedChangedBundles: []string{"main.js", "vendor.js"},
+		},
+		{
+			name: "unchanged bundles ignored",
+			before: Stats{
+				BundleSizes: map[string]int64{
+					"main.js": 100000,
+				},
+				BundleGzipSizes: map[string]int64{
+					"main.js": 30000,
+				},
+			},
+			after: Stats{
+				BundleSizes: map[string]int64{
+					"main.js": 100000,
+				},
+				BundleGzipSizes: map[string]int64{
+					"main.js": 30000,
+				},
+			},
+			expectedNewBundles:     []string{},
+			expectedChangedBundles: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := analyzeBundles(tt.before, tt.after)
+
+			newBundleNames := make([]string, len(result.newBundles))
+			for i, b := range result.newBundles {
+				newBundleNames[i] = b.name
+			}
+
+			require.ElementsMatch(t, tt.expectedNewBundles, newBundleNames)
+
+			changedBundleNames := make([]string, len(result.changedBundles))
+			for i, b := range result.changedBundles {
+				changedBundleNames[i] = b.name
+			}
+
+			require.ElementsMatch(t, tt.expectedChangedBundles, changedBundleNames)
+
+			for _, b := range result.newBundles {
+				require.True(t, b.change.isNew)
+			}
+		})
+	}
+}

--- a/bot/internal/webassets/comment.go
+++ b/bot/internal/webassets/comment.go
@@ -1,0 +1,306 @@
+package webassets
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"strings"
+)
+
+const (
+	commentHeader = "# 📦 Bundle Size Report"
+)
+
+const (
+	subHeadingLevel = 3
+)
+
+func IsBotComment(comment string) bool {
+	return strings.HasPrefix(comment, commentHeader)
+}
+
+func renderHeader(w io.Writer) {
+	fmt.Fprintf(w, "%s\n\n", commentHeader)
+}
+
+func renderHeading(w io.Writer, level int, text string) {
+	if level < 1 || level > 6 {
+		level = 1
+	}
+	fmt.Fprintf(w, "%s %s\n", strings.Repeat("#", level), text)
+}
+
+func renderNewBundles(w io.Writer, bundles []bundleChange) {
+	fmt.Fprint(w, "### 🆕 New Bundles\n")
+
+	headers := []string{"Bundle", "Size"}
+	rows := make([][]string, len(bundles))
+
+	for i, bc := range bundles {
+		rows[i] = []string{
+			fmt.Sprintf("`%s`", bc.name),
+			fmt.Sprintf("%s (%s gz)", formatBytes(bc.size), formatBytes(bc.gzipSize)),
+		}
+	}
+
+	fmt.Fprint(w, generateMarkdownTable(headers, rows))
+	fmt.Fprint(w, "\n\n")
+}
+
+func renderBundleChanges(w io.Writer, changes []bundleChange) {
+	fmt.Fprint(w, "### 📊 Bundle Changes\n")
+
+	headers := []string{"Bundle", "Size", "Change"}
+	rows := make([][]string, len(changes))
+
+	for i, bc := range changes {
+		rows[i] = []string{
+			fmt.Sprintf("`%s`", bc.name),
+			fmt.Sprintf("%s (%s gz)", formatBytes(bc.size), formatBytes(bc.gzipSize)),
+			formatSizeChange(bc.change, "file", false),
+		}
+	}
+
+	fmt.Fprint(w, generateMarkdownTable(headers, rows))
+	fmt.Fprint(w, "\n\n")
+}
+
+func renderNewDependencies(w io.Writer, modules []moduleChange) {
+	fmt.Fprint(w, "### 🆕 New Dependencies\n")
+
+	limit := newDependenciesLimit
+	if len(modules) < limit {
+		limit = len(modules)
+	}
+
+	headers := []string{"Package", "Size"}
+	rows := make([][]string, 0, limit+1)
+
+	for i := 0; i < limit; i++ {
+		module := modules[i]
+		rows = append(rows, []string{
+			fmt.Sprintf("`%s`", module.name),
+			formatSize(module.size, module.gzipSize),
+		})
+	}
+
+	if len(modules) > limit {
+		rows = append(rows, []string{
+			fmt.Sprintf("_...and %d more_", len(modules)-limit),
+			"",
+		})
+	}
+
+	fmt.Fprint(w, generateMarkdownTable(headers, rows))
+	fmt.Fprint(w, "\n\n")
+}
+
+func renderIncreasedDependencies(w io.Writer, modules []moduleChange) {
+	fmt.Fprint(w, "### 📈 Increased Dependencies (>5KB)\n")
+
+	limit := increasedDependenciesLimit
+	if len(modules) < limit {
+		limit = len(modules)
+	}
+
+	headers := []string{"Package", "Size", "Change"}
+	rows := make([][]string, 0, limit+1)
+
+	for i := 0; i < limit; i++ {
+		module := modules[i]
+		color := getChangeColor(module.change.diff, "module", false)
+		rows = append(rows, []string{
+			fmt.Sprintf("`%s`", module.name),
+			formatSize(module.size, module.gzipSize),
+			fmt.Sprintf("+%s (+%.1f%%) ⬆️ %s",
+				formatBytes(module.change.diff),
+				module.change.percentChange,
+				color),
+		})
+	}
+
+	if len(modules) > limit {
+		rows = append(rows, []string{
+			fmt.Sprintf("_...and %d more_", len(modules)-limit),
+			"",
+			"",
+		})
+	}
+
+	fmt.Fprint(w, generateMarkdownTable(headers, rows))
+	fmt.Fprint(w, "\n\n")
+}
+
+func renderNewFiles(w io.Writer, files []moduleChange) {
+	limit := newFilesLimit
+	if len(files) < limit {
+		limit = len(files)
+	}
+
+	fmt.Fprintf(w, "### 📄 New Files (Top %d)\n", limit)
+
+	headers := []string{"File", "Size"}
+	rows := make([][]string, 0, limit+1)
+
+	for i := 0; i < limit; i++ {
+		file := files[i]
+		rows = append(rows, []string{
+			fmt.Sprintf("`%s`", file.name),
+			formatSize(file.size, file.gzipSize),
+		})
+	}
+
+	if len(files) > limit {
+		rows = append(rows, []string{
+			fmt.Sprintf("_...and %d more_", len(files)-limit),
+			"",
+		})
+	}
+
+	fmt.Fprint(w, generateMarkdownTable(headers, rows))
+	fmt.Fprint(w, "\n\n")
+}
+
+func renderDetailsStart(w io.Writer, title string) {
+	fmt.Fprintf(w, "<details>\n")
+	fmt.Fprintf(w, "<summary><strong>%s</strong></summary>\n\n", title)
+}
+
+func renderDetailsEnd(w io.Writer) {
+	fmt.Fprint(w, "\n\n</details>\n")
+}
+
+func renderTopDependencies(w io.Writer, modules []moduleChange) {
+	fmt.Fprintf(w, "### Top %d Dependencies\n", numberOfTopModules)
+
+	limit := numberOfTopModules
+	if len(modules) < limit {
+		limit = len(modules)
+	}
+
+	headers := []string{"Package", "Size"}
+	rows := make([][]string, limit)
+
+	for i := 0; i < limit; i++ {
+		module := modules[i]
+		rows[i] = []string{
+			fmt.Sprintf("`%s`", module.name),
+			formatSize(module.size, module.gzipSize),
+		}
+	}
+
+	fmt.Fprint(w, generateMarkdownTable(headers, rows))
+}
+
+func renderSubHeading(w io.Writer, text string) {
+	renderHeading(w, subHeadingLevel, text)
+}
+
+func renderSummary(w io.Writer, totalChange, totalGzipChange sizeChange) {
+	renderSubHeading(w, "Summary")
+
+	fmt.Fprintf(w, "**Total Size:** %s\n", formatSizeChange(totalChange, "file", false))
+	fmt.Fprintf(w, "**Gzipped:** %s\n\n", formatSizeChange(totalGzipChange, "file", true))
+}
+
+func calculateCompressionRatio(totalSize, totalGzipSize int64) float64 {
+	if totalSize == 0 {
+		return 0.0
+	}
+	return float64(totalSize-totalGzipSize) / float64(totalSize) * 100
+}
+
+func formatBytes(bytes int64) string {
+	if bytes == 0 {
+		return "0 B"
+	}
+
+	sizes := []string{"B", "KB", "MB", "GB", "TB"}
+	i := int(math.Floor(math.Log(float64(bytes)) / math.Log(1024)))
+
+	if i >= len(sizes) {
+		i = len(sizes) - 1
+	}
+
+	return fmt.Sprintf("%.2f %s", float64(bytes)/math.Pow(1024, float64(i)), sizes[i])
+}
+
+func formatSize(size, gzipSize int64) string {
+	return fmt.Sprintf("%s (%s gzipped)", formatBytes(size), formatBytes(gzipSize))
+}
+
+func formatSizeChange(change sizeChange, thresholdType string, gzipped bool) string {
+	sign := "-"
+	percentSign := ""
+	if change.diff >= 0 {
+		sign = "+"
+		percentSign = "+"
+	}
+
+	percentStr := fmt.Sprintf("%.1f", change.percentChange)
+	indicator := getChangeIndicator(change, thresholdType, gzipped)
+
+	abs := int64(math.Abs(float64(change.diff)))
+
+	if change.isNew {
+		return fmt.Sprintf("🆕 %s (%s%s)",
+			formatBytes(change.after),
+			sign,
+			formatBytes(abs))
+	}
+
+	return fmt.Sprintf("%s (%s%s, %s%s%%) %s",
+		formatBytes(change.after),
+		sign,
+		formatBytes(abs),
+		percentSign,
+		percentStr,
+		indicator)
+}
+
+func getChangeColor(diff int64, thresholdType string, gzipped bool) string {
+	if diff < 0 {
+		return "🟢"
+	}
+
+	var warningThreshold, dangerThreshold int64
+	switch thresholdType {
+	case "file":
+		if gzipped {
+			warningThreshold = fileGzipThresholdWarning
+			dangerThreshold = fileGzipThresholdDanger
+		} else {
+			warningThreshold = fileThresholdWarning
+			dangerThreshold = fileThresholdDanger
+		}
+	default:
+		warningThreshold = moduleThresholdWarning
+		dangerThreshold = moduleThresholdDanger
+	}
+
+	if diff > dangerThreshold {
+		return "🔴"
+	}
+
+	if diff > warningThreshold {
+		return "🟡"
+	}
+
+	return "🟢"
+}
+
+func getChangeIndicator(change sizeChange, thresholdType string, gzipped bool) string {
+	if change.diff == 0 {
+		return "➡️"
+	}
+
+	if change.diff > significantIncreaseThreshold {
+		return fmt.Sprintf("⬆️ %s", getChangeColor(change.diff, thresholdType, gzipped))
+	}
+
+	if change.diff < 0 {
+		return "⬇️ 🟢"
+	}
+
+	return "⬆️ 🟢"
+}

--- a/bot/internal/webassets/comment_test.go
+++ b/bot/internal/webassets/comment_test.go
@@ -1,0 +1,375 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webassets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsBotComment(t *testing.T) {
+	tests := []struct {
+		name     string
+		comment  string
+		expected bool
+	}{
+		{
+			name:     "valid bot comment",
+			comment:  "# 📦 Bundle Size Report\n\nSome content",
+			expected: true,
+		},
+		{
+			name:     "valid bot comment without content",
+			comment:  "# 📦 Bundle Size Report",
+			expected: true,
+		},
+		{
+			name:     "not a bot comment",
+			comment:  "This is a regular comment",
+			expected: false,
+		},
+		{
+			name:     "similar but not exact header",
+			comment:  "## 📦 Bundle Size Report",
+			expected: false,
+		},
+		{
+			name:     "header in middle of comment",
+			comment:  "Some text\n# 📦 Bundle Size Report",
+			expected: false,
+		},
+		{
+			name:     "empty comment",
+			comment:  "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsBotComment(tt.comment)
+
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		bytes    int64
+		expected string
+	}{
+		{
+			name:     "zero bytes",
+			bytes:    0,
+			expected: "0 B",
+		},
+		{
+			name:     "bytes",
+			bytes:    500,
+			expected: "500.00 B",
+		},
+		{
+			name:     "kilobytes",
+			bytes:    1536,
+			expected: "1.50 KB",
+		},
+		{
+			name:     "megabytes",
+			bytes:    1048576,
+			expected: "1.00 MB",
+		},
+		{
+			name:     "gigabytes",
+			bytes:    1073741824,
+			expected: "1.00 GB",
+		},
+		{
+			name:     "large kilobytes",
+			bytes:    102400,
+			expected: "100.00 KB",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatBytes(tt.bytes)
+
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetChangeColor(t *testing.T) {
+	tests := []struct {
+		name          string
+		diff          int64
+		thresholdType string
+		gzipped       bool
+		expected      string
+	}{
+		{
+			name:          "negative change (improvement)",
+			diff:          -10000,
+			thresholdType: "file",
+			gzipped:       false,
+			expected:      "🟢",
+		},
+		{
+			name:          "small increase - module",
+			diff:          10000,
+			thresholdType: "module",
+			gzipped:       false,
+			expected:      "🟢",
+		},
+		{
+			name:          "warning threshold - module",
+			diff:          25000,
+			thresholdType: "module",
+			gzipped:       false,
+			expected:      "🟡",
+		},
+		{
+			name:          "danger threshold - module",
+			diff:          60000,
+			thresholdType: "module",
+			gzipped:       false,
+			expected:      "🔴",
+		},
+		{
+			name:          "warning threshold - file",
+			diff:          60000,
+			thresholdType: "file",
+			gzipped:       false,
+			expected:      "🟡",
+		},
+		{
+			name:          "danger threshold - file",
+			diff:          110000,
+			thresholdType: "file",
+			gzipped:       false,
+			expected:      "🔴",
+		},
+		{
+			name:          "warning threshold - gzipped file",
+			diff:          20000,
+			thresholdType: "file",
+			gzipped:       true,
+			expected:      "🟡",
+		},
+		{
+			name:          "danger threshold - gzipped file",
+			diff:          35000,
+			thresholdType: "file",
+			gzipped:       true,
+			expected:      "🔴",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getChangeColor(tt.diff, tt.thresholdType, tt.gzipped)
+
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetChangeIndicator(t *testing.T) {
+	tests := []struct {
+		name          string
+		change        sizeChange
+		thresholdType string
+		gzipped       bool
+		expected      string
+	}{
+		{
+			name: "no change",
+			change: sizeChange{
+				diff: 0,
+			},
+			thresholdType: "file",
+			gzipped:       false,
+			expected:      "➡️",
+		},
+		{
+			name: "small increase",
+			change: sizeChange{
+				diff: 1000,
+			},
+			thresholdType: "file",
+			gzipped:       false,
+			expected:      "⬆️ 🟢",
+		},
+		{
+			name: "significant increase - green",
+			change: sizeChange{
+				diff: 10000,
+			},
+			thresholdType: "module",
+			gzipped:       false,
+			expected:      "⬆️ 🟢",
+		},
+		{
+			name: "significant increase - yellow",
+			change: sizeChange{
+				diff: 25000,
+			},
+			thresholdType: "module",
+			gzipped:       false,
+			expected:      "⬆️ 🟡",
+		},
+		{
+			name: "decrease",
+			change: sizeChange{
+				diff: -10000,
+			},
+			thresholdType: "file",
+			gzipped:       false,
+			expected:      "⬇️ 🟢",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getChangeIndicator(tt.change, tt.thresholdType, tt.gzipped)
+
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatSizeChange(t *testing.T) {
+	tests := []struct {
+		name          string
+		change        sizeChange
+		thresholdType string
+		gzipped       bool
+		expected      string
+	}{
+		{
+			name:     "new item",
+			change:   calculateSizeChange(0, 100000),
+			expected: "🆕 97.66 KB (+97.66 KB)",
+		},
+		{
+			name:          "increase",
+			change:        calculateSizeChange(100000, 150000),
+			thresholdType: "file",
+			gzipped:       false,
+			expected:      "146.48 KB (+48.83 KB, +50.0%) ⬆️ 🟢",
+		},
+		{
+			name:          "decrease",
+			change:        calculateSizeChange(150000, 100000),
+			thresholdType: "file",
+			gzipped:       false,
+			expected:      "97.66 KB (-48.83 KB, -33.3%) ⬇️ 🟢",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatSizeChange(tt.change, tt.thresholdType, tt.gzipped)
+
+			require.Equal(t, tt.expected, result)
+
+			if tt.change.isNew {
+				require.Contains(t, result, "🆕")
+			}
+
+			require.Contains(t, result, "KB")
+
+			if !tt.change.isNew && tt.change.diff != 0 {
+				require.Contains(t, result, "%")
+			}
+		})
+	}
+}
+
+func TestRenderSummary(t *testing.T) {
+	var b strings.Builder
+
+	totalChange := sizeChange{
+		before:        300000,
+		after:         350000,
+		diff:          50000,
+		percentChange: 16.7,
+	}
+	totalGzipChange := sizeChange{
+		before:        90000,
+		after:         105000,
+		diff:          15000,
+		percentChange: 16.7,
+	}
+
+	renderSummary(&b, totalChange, totalGzipChange)
+	result := b.String()
+
+	require.Contains(t, result, "### Summary")
+	require.Contains(t, result, "**Total Size:** 341.80 KB (+48.83 KB, +16.7%) ⬆️ 🟢")
+	require.Contains(t, result, "**Gzipped:** 102.54 KB (+14.65 KB, +16.7%) ⬆️ 🟢")
+}
+
+func TestRenderTopDependencies(t *testing.T) {
+	var b strings.Builder
+
+	modules := []moduleChange{
+		{
+			name:     "react",
+			size:     500000,
+			gzipSize: 150000,
+		},
+		{
+			name:     "lodash",
+			size:     300000,
+			gzipSize: 90000,
+		},
+		{
+			name:     "vue",
+			size:     250000,
+			gzipSize: 75000,
+		},
+		{
+			name:     "moment",
+			size:     200000,
+			gzipSize: 60000,
+		},
+		{
+			name:     "axios",
+			size:     150000,
+			gzipSize: 45000,
+		},
+	}
+
+	renderTopDependencies(&b, modules)
+	result := b.String()
+
+	require.Contains(t, result, "### Top 20 Dependencies")
+
+	require.Contains(t, result, "`react`")
+	require.Contains(t, result, "`lodash`")
+	require.Contains(t, result, "`vue`")
+	require.Contains(t, result, "`moment`")
+	require.Contains(t, result, "`axios`")
+
+	require.Contains(t, result, "488.28 KB (146.48 KB gzipped)")
+	require.Contains(t, result, "292.97 KB (87.89 KB gzipped)")
+}

--- a/bot/internal/webassets/compare.go
+++ b/bot/internal/webassets/compare.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webassets
+
+import (
+	"strings"
+)
+
+type comparison struct {
+	bundleAnalysis
+	fileAnalysis
+	moduleAnalysis
+	totalChange     sizeChange
+	totalGzipChange sizeChange
+}
+
+type sizeChange struct {
+	before        int64
+	after         int64
+	diff          int64
+	percentChange float64
+	isNew         bool
+}
+
+func Compare(before, after Stats) (string, error) {
+	c := comparison{
+		bundleAnalysis:  analyzeBundles(before, after),
+		fileAnalysis:    analyzeFiles(before, after),
+		moduleAnalysis:  analyzeModules(before, after),
+		totalChange:     calculateSizeChange(before.TotalSize, after.TotalSize),
+		totalGzipChange: calculateSizeChange(before.TotalGzipSize, after.TotalGzipSize),
+	}
+
+	return c.String(), nil
+}
+
+// String creates a formatted string representation of the comparison report.
+func (c comparison) String() string {
+	var b strings.Builder
+
+	renderHeader(&b)
+	renderSummary(&b, c.totalChange, c.totalGzipChange)
+
+	renderDetailsStart(&b, "Full Report")
+
+	if len(c.newBundles) > 0 {
+		renderNewBundles(&b, c.newBundles)
+	}
+
+	if len(c.changedBundles) > 0 {
+		renderBundleChanges(&b, c.changedBundles)
+	}
+
+	if len(c.newModules) > 0 {
+		renderNewDependencies(&b, c.newModules)
+	}
+
+	if len(c.increasedModules) > 0 {
+		renderIncreasedDependencies(&b, c.increasedModules)
+	}
+
+	if len(c.newFiles) > 0 {
+		renderNewFiles(&b, c.newFiles)
+	}
+
+	renderTopDependencies(&b, c.allModules)
+
+	renderDetailsEnd(&b)
+
+	return b.String()
+}
+
+func calculateSizeChange(before, after int64) sizeChange {
+	var percentChange float64
+	var isNew bool
+
+	diff := after - before
+
+	if before == 0 {
+		if after == 0 {
+			percentChange = 0
+		} else {
+			percentChange = 100
+			isNew = true
+		}
+	} else {
+		percentChange = float64(diff) / float64(before) * 100
+	}
+
+	return sizeChange{
+		before:        before,
+		after:         after,
+		diff:          diff,
+		percentChange: percentChange,
+		isNew:         isNew,
+	}
+}

--- a/bot/internal/webassets/compare_test.go
+++ b/bot/internal/webassets/compare_test.go
@@ -1,0 +1,326 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webassets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateSizeChange(t *testing.T) {
+	tests := []struct {
+		name            string
+		before          int64
+		after           int64
+		expectedDiff    int64
+		expectedPercent float64
+		expectedIsNew   bool
+	}{
+		{
+			name:            "increase",
+			before:          100000,
+			after:           150000,
+			expectedDiff:    50000,
+			expectedPercent: 50.0,
+			expectedIsNew:   false,
+		},
+		{
+			name:            "decrease",
+			before:          150000,
+			after:           100000,
+			expectedDiff:    -50000,
+			expectedPercent: -33.33333333333333,
+			expectedIsNew:   false,
+		},
+		{
+			name:            "no change",
+			before:          100000,
+			after:           100000,
+			expectedDiff:    0,
+			expectedPercent: 0.0,
+			expectedIsNew:   false,
+		},
+		{
+			name:            "new file",
+			before:          0,
+			after:           100000,
+			expectedDiff:    100000,
+			expectedPercent: 100.0,
+			expectedIsNew:   true,
+		},
+		{
+			name:            "removed file",
+			before:          100000,
+			after:           0,
+			expectedDiff:    -100000,
+			expectedPercent: -100.0,
+			expectedIsNew:   false,
+		},
+		{
+			name:            "both zero",
+			before:          0,
+			after:           0,
+			expectedDiff:    0,
+			expectedPercent: 0.0,
+			expectedIsNew:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateSizeChange(tt.before, tt.after)
+
+			require.Equal(t, tt.before, result.before)
+			require.Equal(t, tt.after, result.after)
+			require.Equal(t, tt.expectedDiff, result.diff)
+			require.Equal(t, tt.expectedPercent, result.percentChange)
+			require.Equal(t, tt.expectedIsNew, result.isNew)
+		})
+	}
+}
+
+func TestCompare(t *testing.T) {
+	before := Stats{
+		BundleSizes: map[string]int64{
+			"main.js":   100000,
+			"vendor.js": 200000,
+		},
+		BundleGzipSizes: map[string]int64{
+			"main.js":   30000,
+			"vendor.js": 60000,
+		},
+		FileSizes: map[string]int64{
+			"app.js": 50000,
+		},
+		FileGzipSizes: map[string]int64{
+			"app.js": 15000,
+		},
+		ModuleSizes: map[string]int64{
+			"react":     150000,
+			"react-dom": 120000,
+		},
+		ModuleGzipSizes: map[string]int64{
+			"react":     45000,
+			"react-dom": 36000,
+		},
+		TotalSize:     300000,
+		TotalGzipSize: 90000,
+	}
+
+	after := Stats{
+		BundleSizes: map[string]int64{
+			"main.js":   110000, // increased
+			"vendor.js": 200000, // unchanged
+			"worker.js": 50000,  // new
+		},
+		BundleGzipSizes: map[string]int64{
+			"main.js":   33000,
+			"vendor.js": 60000,
+			"worker.js": 15000,
+		},
+		FileSizes: map[string]int64{
+			"app.js":     50000,
+			"vendor.js":  100000, // new
+			"styles.css": 25000,  // new
+		},
+		FileGzipSizes: map[string]int64{
+			"app.js":     15000,
+			"vendor.js":  30000,
+			"styles.css": 8000,
+		},
+		ModuleSizes: map[string]int64{
+			"react":     150000,
+			"react-dom": 130000, // increased by 10KB
+			"lodash":    80000,  // new
+		},
+		ModuleGzipSizes: map[string]int64{
+			"react":     45000,
+			"react-dom": 39000,
+			"lodash":    24000,
+		},
+		TotalSize:     350000,
+		TotalGzipSize: 105000,
+	}
+
+	result, err := Compare(before, after)
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+
+	require.Contains(t, result, "# 📦 Bundle Size Report")
+	require.Contains(t, result, "### Summary")
+	require.Contains(t, result, "**Total Size:**")
+	require.Contains(t, result, "**Gzipped:**")
+
+	require.Contains(t, result, "### 🆕 New Bundles")
+	require.Contains(t, result, "worker.js")
+
+	require.Contains(t, result, "### 📊 Bundle Changes")
+	require.Contains(t, result, "main.js")
+
+	require.Contains(t, result, "### 🆕 New Dependencies")
+	require.Contains(t, result, "lodash")
+
+	require.Contains(t, result, "### 📈 Increased Dependencies")
+	require.Contains(t, result, "react-dom")
+
+	require.Contains(t, result, "### 📄 New Files")
+	require.Contains(t, result, "vendor.js")
+	require.Contains(t, result, "styles.css")
+
+	require.Contains(t, result, "Full Report")
+	require.Contains(t, result, "<details>")
+	require.Contains(t, result, "</details>")
+}
+
+func TestComparisonString_EmptyChanges(t *testing.T) {
+	before := Stats{
+		BundleSizes: map[string]int64{
+			"main.js": 100000,
+		},
+		BundleGzipSizes: map[string]int64{
+			"main.js": 30000,
+		},
+		TotalSize:     100000,
+		TotalGzipSize: 30000,
+	}
+
+	after := Stats{
+		BundleSizes: map[string]int64{
+			"main.js": 100000,
+		},
+		BundleGzipSizes: map[string]int64{
+			"main.js": 30000,
+		},
+		TotalSize:     100000,
+		TotalGzipSize: 30000,
+	}
+
+	result, err := Compare(before, after)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+
+	require.Contains(t, result, "# 📦 Bundle Size Report")
+	require.Contains(t, result, "### Summary")
+
+	require.NotContains(t, result, "### 🆕 New Bundles")
+	require.NotContains(t, result, "### 📊 Bundle Changes")
+	require.NotContains(t, result, "### 🆕 New Dependencies")
+	require.NotContains(t, result, "### 📈 Increased Dependencies")
+}
+
+func TestComparison_LargeLists(t *testing.T) {
+	before := Stats{
+		ModuleSizes:     map[string]int64{},
+		ModuleGzipSizes: map[string]int64{},
+		FileSizes:       map[string]int64{},
+		FileGzipSizes:   map[string]int64{},
+		BundleSizes:     map[string]int64{},
+		BundleGzipSizes: map[string]int64{},
+	}
+
+	after := Stats{
+		ModuleSizes:     map[string]int64{},
+		ModuleGzipSizes: map[string]int64{},
+		FileSizes:       map[string]int64{},
+		FileGzipSizes:   map[string]int64{},
+		BundleSizes:     map[string]int64{},
+		BundleGzipSizes: map[string]int64{},
+	}
+
+	for i := 0; i < 15; i++ {
+		moduleName := strings.Repeat("a", i+1)
+
+		after.ModuleSizes[moduleName] = int64(100000 + i*1000)
+		after.ModuleGzipSizes[moduleName] = int64(30000 + i*300)
+	}
+
+	for i := 0; i < 10; i++ {
+		fileName := strings.Repeat("b", i+1) + ".js"
+
+		after.FileSizes[fileName] = int64(50000 + i*1000)
+		after.FileGzipSizes[fileName] = int64(15000 + i*300)
+	}
+
+	result, err := Compare(before, after)
+
+	require.NoError(t, err)
+
+	require.Contains(t, result, "...and")
+	require.Contains(t, result, "more")
+
+	newDepsStart := strings.Index(result, "### 🆕 New Dependencies")
+	require.NotEqual(t, -1, newDepsStart)
+
+	restOfResult := result[newDepsStart:]
+	nextSectionIndex := strings.Index(restOfResult[1:], "###")
+	detailsIndex := strings.Index(restOfResult, "<details>")
+
+	var sectionEnd int
+	if nextSectionIndex != -1 && (detailsIndex == -1 || nextSectionIndex < detailsIndex) {
+		sectionEnd = nextSectionIndex + 1
+	} else if detailsIndex != -1 {
+		sectionEnd = detailsIndex
+	} else {
+		sectionEnd = len(restOfResult)
+	}
+
+	newDepsSection := restOfResult[:sectionEnd]
+
+	moduleCount := 0
+	for i := 1; i <= 15; i++ {
+		moduleName := strings.Repeat("a", i)
+		if strings.Contains(newDepsSection, "`"+moduleName+"`") {
+			moduleCount++
+		}
+	}
+
+	require.Equal(t, newDependenciesLimit, moduleCount)
+	require.Contains(t, newDepsSection, "and 5 more")
+
+	newFilesStart := strings.Index(result, "### 📄 New Files")
+
+	require.NotEqual(t, -1, newFilesStart)
+
+	restOfResult = result[newFilesStart:]
+	nextSectionIndex = strings.Index(restOfResult[1:], "###")
+	detailsIndex = strings.Index(restOfResult, "<details>")
+
+	if nextSectionIndex != -1 && (detailsIndex == -1 || nextSectionIndex < detailsIndex) {
+		sectionEnd = nextSectionIndex + 1
+	} else if detailsIndex != -1 {
+		sectionEnd = detailsIndex
+	} else {
+		sectionEnd = len(restOfResult)
+	}
+
+	newFilesSection := restOfResult[:sectionEnd]
+
+	fileCount := 0
+	for i := 1; i <= 10; i++ {
+		fileName := strings.Repeat("b", i) + ".js"
+
+		if strings.Contains(newFilesSection, "`"+fileName+"`") {
+			fileCount++
+		}
+	}
+
+	require.Equal(t, newFilesLimit, fileCount)
+	require.Contains(t, newFilesSection, "and 5 more")
+}

--- a/bot/internal/webassets/constants.go
+++ b/bot/internal/webassets/constants.go
@@ -1,0 +1,21 @@
+package webassets
+
+const (
+	numberOfTopModules           = 20
+
+	newDependenciesLimit       = 10
+	increasedDependenciesLimit = 5
+	newFilesLimit              = 5
+)
+
+const (
+	significantIncreaseThreshold = 5 * 1024 // 5 KiB
+
+	moduleThresholdDanger  = 50 * 1024 // 50 KiB
+	moduleThresholdWarning = 20 * 1024 // 20 KiB
+
+	fileThresholdDanger      = 100 * 1024 // 100 KiB
+	fileThresholdWarning     = 50 * 1024 // 50 KiB
+	fileGzipThresholdDanger  = 30 * 1024 // 30 KiB
+	fileGzipThresholdWarning = 15 * 1024 // 15 KiB
+)

--- a/bot/internal/webassets/constants.go
+++ b/bot/internal/webassets/constants.go
@@ -1,7 +1,7 @@
 package webassets
 
 const (
-	numberOfTopModules           = 20
+	numberOfTopModules = 20
 
 	newDependenciesLimit       = 10
 	increasedDependenciesLimit = 5
@@ -15,7 +15,7 @@ const (
 	moduleThresholdWarning = 20 * 1024 // 20 KiB
 
 	fileThresholdDanger      = 100 * 1024 // 100 KiB
-	fileThresholdWarning     = 50 * 1024 // 50 KiB
-	fileGzipThresholdDanger  = 30 * 1024 // 30 KiB
-	fileGzipThresholdWarning = 15 * 1024 // 15 KiB
+	fileThresholdWarning     = 50 * 1024  // 50 KiB
+	fileGzipThresholdDanger  = 30 * 1024  // 30 KiB
+	fileGzipThresholdWarning = 15 * 1024  // 15 KiB
 )

--- a/bot/internal/webassets/stats.go
+++ b/bot/internal/webassets/stats.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webassets
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/gravitational/trace"
+)
+
+type Stats struct {
+	BundleSizes     map[string]int64 `json:"bundleSizes"`
+	BundleGzipSizes map[string]int64 `json:"bundleGzipSizes"`
+	FileSizes       map[string]int64 `json:"fileSizes"`
+	FileGzipSizes   map[string]int64 `json:"fileGzipSizes"`
+	ModuleSizes     map[string]int64 `json:"moduleSizes"`
+	ModuleGzipSizes map[string]int64 `json:"moduleGzipSizes"`
+	TotalSize       int64            `json:"totalSize"`
+	TotalGzipSize   int64            `json:"totalGzipSize"`
+}
+
+func LoadStats(path string) (Stats, error) {
+	var report Stats
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return report, trace.Wrap(err, "failed to read stats report from %q", path)
+	}
+
+	if err := json.Unmarshal(data, &report); err != nil {
+		return report, trace.Wrap(err, "failed to unmarshal stats report from %q", path)
+	}
+
+	return report, nil
+}

--- a/bot/internal/webassets/stats_test.go
+++ b/bot/internal/webassets/stats_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webassets
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadStats(t *testing.T) {
+	tests := []struct {
+		name        string
+		stats       Stats
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid stats",
+			stats: Stats{
+				BundleSizes: map[string]int64{
+					"main.js":   100000,
+					"vendor.js": 200000,
+				},
+				BundleGzipSizes: map[string]int64{
+					"main.js":   30000,
+					"vendor.js": 60000,
+				},
+				FileSizes: map[string]int64{
+					"app.js":    50000,
+					"styles.css": 25000,
+				},
+				FileGzipSizes: map[string]int64{
+					"app.js":    15000,
+					"styles.css": 8000,
+				},
+				ModuleSizes: map[string]int64{
+					"react":     150000,
+					"react-dom": 120000,
+				},
+				ModuleGzipSizes: map[string]int64{
+					"react":     45000,
+					"react-dom": 36000,
+				},
+				TotalSize:     300000,
+				TotalGzipSize: 90000,
+			},
+		},
+		{
+			name: "empty stats",
+			stats: Stats{
+				BundleSizes:     map[string]int64{},
+				BundleGzipSizes: map[string]int64{},
+				FileSizes:       map[string]int64{},
+				FileGzipSizes:   map[string]int64{},
+				ModuleSizes:     map[string]int64{},
+				ModuleGzipSizes: map[string]int64{},
+				TotalSize:       0,
+				TotalGzipSize:   0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory
+			tmpDir := t.TempDir()
+			statsFile := filepath.Join(tmpDir, "stats.json")
+
+			// Write stats to file
+			data, err := json.Marshal(tt.stats)
+			require.NoError(t, err)
+			err = os.WriteFile(statsFile, data, 0644)
+			require.NoError(t, err)
+
+			// Load and verify
+			loaded, err := LoadStats(statsFile)
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.stats, loaded)
+			}
+		})
+	}
+}
+
+func TestLoadStats_Errors(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(string) string
+		errorMsg  string
+	}{
+		{
+			name: "file not found",
+			setup: func(tmpDir string) string {
+				return filepath.Join(tmpDir, "nonexistent.json")
+			},
+			errorMsg: "failed to read stats report",
+		},
+		{
+			name: "invalid JSON",
+			setup: func(tmpDir string) string {
+				path := filepath.Join(tmpDir, "invalid.json")
+				err := os.WriteFile(path, []byte("not valid json"), 0644)
+				require.NoError(t, err)
+				return path
+			},
+			errorMsg: "failed to unmarshal stats report",
+		},
+		{
+			name: "wrong JSON structure",
+			setup: func(tmpDir string) string {
+				path := filepath.Join(tmpDir, "wrong.json")
+				// This JSON is valid but doesn't match the Stats structure
+				// It will unmarshal successfully but with empty/zero values
+				err := os.WriteFile(path, []byte(`{"wrong": "structure"}`), 0644)
+				require.NoError(t, err)
+				return path
+			},
+			errorMsg: "", // Remove error expectation since it unmarshals successfully
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			path := tt.setup(tmpDir)
+
+			stats, err := LoadStats(path)
+			if tt.errorMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				// For wrong JSON structure, it should load but with empty values
+				require.NoError(t, err)
+				require.Empty(t, stats.BundleSizes)
+				require.Empty(t, stats.ModuleSizes)
+				require.Zero(t, stats.TotalSize)
+			}
+		})
+	}
+}

--- a/bot/internal/webassets/stats_test.go
+++ b/bot/internal/webassets/stats_test.go
@@ -44,11 +44,11 @@ func TestLoadStats(t *testing.T) {
 					"vendor.js": 60000,
 				},
 				FileSizes: map[string]int64{
-					"app.js":    50000,
+					"app.js":     50000,
 					"styles.css": 25000,
 				},
 				FileGzipSizes: map[string]int64{
-					"app.js":    15000,
+					"app.js":     15000,
 					"styles.css": 8000,
 				},
 				ModuleSizes: map[string]int64{
@@ -105,9 +105,9 @@ func TestLoadStats(t *testing.T) {
 
 func TestLoadStats_Errors(t *testing.T) {
 	tests := []struct {
-		name      string
-		setup     func(string) string
-		errorMsg  string
+		name     string
+		setup    func(string) string
+		errorMsg string
 	}{
 		{
 			name: "file not found",

--- a/bot/internal/webassets/table.go
+++ b/bot/internal/webassets/table.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webassets
+
+import (
+	"fmt"
+	"strings"
+)
+
+type tableBuilder struct {
+	headers []string
+	rows    [][]string
+}
+
+func newTableBuilder(headers []string) *tableBuilder {
+	tb := &tableBuilder{
+		headers: headers,
+		rows:    [][]string{},
+	}
+
+	return tb
+}
+
+func (t *tableBuilder) addRow(row []string) {
+	t.rows = append(t.rows, row)
+}
+
+func (t *tableBuilder) render() string {
+	var result strings.Builder
+
+	headerRow := make([]string, len(t.headers))
+	for i, h := range t.headers {
+		headerRow[i] = fmt.Sprintf(" %s ", h)
+	}
+
+	result.WriteString("|")
+	result.WriteString(strings.Join(headerRow, "|"))
+	result.WriteString("|\n")
+
+	separators := make([]string, len(t.headers))
+	for i := range separators {
+		separators[i] = "---"
+	}
+
+	result.WriteString("|")
+	result.WriteString(strings.Join(separators, "|"))
+	result.WriteString("|\n")
+
+	for _, row := range t.rows {
+		formattedRow := make([]string, len(row))
+		for i, cell := range row {
+			formattedRow[i] = fmt.Sprintf(" %s ", cell)
+		}
+
+		result.WriteString("|")
+		result.WriteString(strings.Join(formattedRow, "|"))
+		result.WriteString("|\n")
+	}
+
+	return result.String()
+}
+
+func generateMarkdownTable(headers []string, rows [][]string) string {
+	tb := newTableBuilder(headers)
+
+	for _, row := range rows {
+		tb.addRow(row)
+	}
+
+	return tb.render()
+}

--- a/bot/internal/webassets/table_test.go
+++ b/bot/internal/webassets/table_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webassets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableBuilder(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  []string
+		rows     [][]string
+		expected []string
+	}{
+		{
+			name:    "simple table",
+			headers: []string{"Name", "Size"},
+			rows: [][]string{
+				{"file1.js", "100 KB"},
+				{"file2.js", "200 KB"},
+			},
+			expected: []string{
+				"| Name | Size |",
+				"|---|---|",
+				"| file1.js | 100 KB |",
+				"| file2.js | 200 KB |",
+			},
+		},
+		{
+			name:    "table with varying column widths",
+			headers: []string{"Short", "Very Long Header"},
+			rows: [][]string{
+				{"a", "b"},
+				{"longer content", "c"},
+			},
+			expected: []string{
+				"| Short | Very Long Header |",
+				"|---|---|",
+				"| a | b |",
+				"| longer content | c |",
+			},
+		},
+		{
+			name:    "empty table",
+			headers: []string{"Column1", "Column2"},
+			rows:    [][]string{},
+			expected: []string{
+				"| Column1 | Column2 |",
+				"|---|---|",
+			},
+		},
+		{
+			name:    "single column table",
+			headers: []string{"Single"},
+			rows: [][]string{
+				{"row1"},
+				{"row2"},
+			},
+			expected: []string{
+				"| Single |",
+				"|---|",
+				"| row1 |",
+				"| row2 |",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tb := newTableBuilder(tt.headers)
+			for _, row := range tt.rows {
+				tb.addRow(row)
+			}
+
+			result := tb.render()
+
+			for _, expected := range tt.expected {
+				require.Contains(t, result, expected)
+			}
+
+			lines := strings.Split(strings.TrimSpace(result), "\n")
+
+			require.GreaterOrEqual(t, len(lines), 2)
+
+			require.True(t, strings.HasPrefix(lines[0], "|"))
+			require.True(t, strings.HasSuffix(lines[0], "|"))
+
+			require.Contains(t, lines[1], "---")
+		})
+	}
+}
+
+func TestGenerateMarkdownTable(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  []string
+		rows     [][]string
+		expected []string
+	}{
+		{
+			name:    "bundle changes table",
+			headers: []string{"Bundle", "Size", "Change"},
+			rows: [][]string{
+				{"`main.js`", "110 KB (33 KB gz)", "+10 KB (+10.0%) ⬆️ 🟢"},
+				{"`vendor.js`", "200 KB (60 KB gz)", "0 KB (0.0%) ➡️"},
+			},
+			expected: []string{
+				"| Bundle | Size | Change |",
+				"| `main.js` | 110 KB (33 KB gz) | +10 KB (+10.0%) ⬆️ 🟢 |",
+				"| `vendor.js` | 200 KB (60 KB gz) | 0 KB (0.0%) ➡️ |",
+			},
+		},
+		{
+			name:    "new dependencies table",
+			headers: []string{"Package", "Size"},
+			rows: [][]string{
+				{"`react`", "150 KB (45 KB gzipped)"},
+				{"`react-dom`", "120 KB (36 KB gzipped)"},
+				{"_...and 5 more_", ""},
+			},
+			expected: []string{
+				"| Package | Size |",
+				"| `react` | 150 KB (45 KB gzipped) |",
+				"| `react-dom` | 120 KB (36 KB gzipped) |",
+				"| _...and 5 more_ |  |",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateMarkdownTable(tt.headers, tt.rows)
+
+			for _, expected := range tt.expected {
+				require.Contains(t, result, expected)
+			}
+
+			lines := strings.Split(strings.TrimSpace(result), "\n")
+
+			for _, line := range lines {
+				require.True(t, strings.HasPrefix(line, "|"))
+				require.True(t, strings.HasSuffix(line, "|"))
+			}
+
+			require.Contains(t, lines[1], "---")
+
+			headerCols := strings.Count(lines[0], "|") - 1
+			for _, line := range lines {
+				cols := strings.Count(line, "|") - 1
+				require.Equal(t, headerCols, cols)
+			}
+		})
+	}
+}
+
+func TestTableBuilder_EdgeCases(t *testing.T) {
+	t.Run("headers with special characters", func(t *testing.T) {
+		tb := newTableBuilder([]string{"Size (KB)", "Change %"})
+		tb.addRow([]string{"100", "+10%"})
+		result := tb.render()
+
+		require.Contains(t, result, "| Size (KB) | Change % |")
+		require.Contains(t, result, "| 100 | +10% |")
+	})
+
+	t.Run("cells with markdown formatting", func(t *testing.T) {
+		tb := newTableBuilder([]string{"File", "Status"})
+		tb.addRow([]string{"`main.js`", "**Updated**"})
+		tb.addRow([]string{"_vendor.js_", "~~Removed~~"})
+		result := tb.render()
+
+		require.Contains(t, result, "| `main.js` | **Updated** |")
+		require.Contains(t, result, "| _vendor.js_ | ~~Removed~~ |")
+	})
+
+	t.Run("empty cells", func(t *testing.T) {
+		tb := newTableBuilder([]string{"Col1", "Col2", "Col3"})
+		tb.addRow([]string{"a", "", "c"})
+		tb.addRow([]string{"", "b", ""})
+		result := tb.render()
+
+		require.Contains(t, result, "| a |  | c |")
+		require.Contains(t, result, "|  | b |  |")
+	})
+
+	t.Run("unicode and emoji", func(t *testing.T) {
+		tb := newTableBuilder([]string{"Status", "Message"})
+		tb.addRow([]string{"🟢", "Success"})
+		tb.addRow([]string{"🔴", "Error"})
+		tb.addRow([]string{"⬆️", "Increased"})
+		result := tb.render()
+
+		require.Contains(t, result, "| 🟢 | Success |")
+		require.Contains(t, result, "| 🔴 | Error |")
+		require.Contains(t, result, "| ⬆️ | Increased |")
+	})
+}

--- a/bot/main.go
+++ b/bot/main.go
@@ -82,6 +82,8 @@ func main() {
 		err = b.CheckChangelog(ctx)
 	case "docpaths":
 		err = b.CheckDocsPathsForMissingRedirects(ctx, flags.teleportClonePath)
+	case "webassets":
+		err = b.CompareWebAssetsStats(ctx, flags.webassetsStats)
 	default:
 		err = trace.BadParameter("unknown workflow: %v", flags.workflow)
 	}
@@ -118,6 +120,8 @@ type flags struct {
 	// teleportClonePath is a relative path to a gravitational/teleport
 	// repository clone.
 	teleportClonePath string
+	// webassetsStats is a comma separated paths for the before and after web assets stats.
+	webassetsStats string
 }
 
 func parseFlags() (flags, error) {
@@ -134,6 +138,7 @@ func parseFlags() (flags, error) {
 		buildDir          = flag.String("builddir", "", "an absolute path to a build directory containing artifacts to be checked for bloat")
 		artifacts         = flag.String("artifacts", "", "a comma separated list of compile artifacts to analyze for bloat")
 		teleportClonePath = flag.String("teleport-path", "", "relative path to a gravitational/teleport clone")
+		webassetsStats    = flag.String("stats", "", "comma separated paths for the before and after web assets stats, e.g. 'before.json,after.json' (webassets workflow only)")
 	)
 	flag.Parse()
 
@@ -177,6 +182,7 @@ func parseFlags() (flags, error) {
 		baseStats:         string(stats),
 		buildDir:          *buildDir,
 		teleportClonePath: *teleportClonePath,
+		webassetsStats:    *webassetsStats,
 	}, nil
 }
 


### PR DESCRIPTION
This adds webasset bundle analysis, taking `--stats path/to/before.json,path/to/after.json` and analysing the results into a comment that is either created or edited.

The stats JSON files are generated by a Vite plugin that will live in the teleport and access-graph codebases (I can't think of an easy way to share it for now)