### PR TITLE
Fix bug in docpaths workflow

### DIFF
--- a/bot/internal/bot/docpaths.go
+++ b/bot/internal/bot/docpaths.go
@@ -111,6 +111,16 @@ func missingRedirectSources(conf []DocsRedirect, files github.PullRequestFiles) 
 		sources[s.Source] = struct{}{}
 	}
 
+	// Make a map of URL paths for added files so we can check whether a
+	// deleted file was actually changed to a category index page or vice
+	// versa.
+	addedPaths := make(map[string]struct{})
+	for _, f := range files {
+		if f.Status == "added" {
+			addedPaths[toURLPath(f.Name)] = struct{}{}
+		}
+	}
+
 	res := []string{}
 	for _, f := range files {
 		if !strings.HasPrefix(f.Name, docsPrefix) {
@@ -130,7 +140,9 @@ func missingRedirectSources(conf []DocsRedirect, files github.PullRequestFiles) 
 			}
 		case "removed":
 			p := toURLPath(f.Name)
-			if _, ok := sources[p]; !ok {
+			_, addedPath := addedPaths[p]
+			_, redirect := sources[p]
+			if !addedPath && !redirect {
 				res = append(res, p)
 			}
 		}

--- a/bot/internal/bot/docpaths_test.go
+++ b/bot/internal/bot/docpaths_test.go
@@ -285,6 +285,36 @@ func TestMissingRedirectSources(t *testing.T) {
 			redirects: []DocsRedirect{},
 			expected:  []string{},
 		},
+		{
+			description: "page replaced with category index",
+			files: []github.PullRequestFile{
+				{
+					Name:   "docs/pages/installation.mdx",
+					Status: "removed",
+				},
+				{
+					Name:   "docs/pages/installation/installation.mdx",
+					Status: "added",
+				},
+			},
+			redirects: []DocsRedirect{},
+			expected:  []string{},
+		},
+		{
+			description: "category index replaced with page",
+			files: []github.PullRequestFile{
+				{
+					Name:   "docs/pages/installation.mdx",
+					Status: "added",
+				},
+				{
+					Name:   "docs/pages/installation/installation.mdx",
+					Status: "removed",
+				},
+			},
+			redirects: []DocsRedirect{},
+			expected:  []string{},
+		},
 	}
 
 	for _, c := range cases {

--- a/bot/internal/github/github.go
+++ b/bot/internal/github/github.go
@@ -251,6 +251,8 @@ type PullRequestFile struct {
 	// Deletions is the number of lines removed from the file
 	Deletions int
 	// Status is either added, removed, modified, renamed, copied, changed, unchanged
+	// See response schema for the current list of statuses:
+	// https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files
 	Status string
 	// PreviousName is the name of the file prior to renaming. The GitHub
 	// API only assigns this if Status is "renamed". For deleted files, the


### PR DESCRIPTION
The docpaths workflow detects whether a pull request renames or removes a docs page without introducing adequate redirects, preventing 404s.

If a pull request changes a docs page (e.g.,
`docs/pages/installation.mdx`) to a category index page (e.g., `docs/pages/installation/installation.mdx`), the URL path for the page does not change, and there is no redirect required. However, the docpaths workflow still marks the change as requiring a redirect. This is because, if a page is removed, the workflow only checks the list of configured redirects. This means that it misses the addition of a category index page.

This change adjusts the redirect checking logic to, if a page was deleted in a pull request, check the PR files for additions. If an addition includes the same URL path as the removed file, there is no need for a redirect.