### PR TITLE
tools/common: Rework output for common test and lint

### DIFF
--- a/.github/workflows/reusable-ci.yaml
+++ b/.github/workflows/reusable-ci.yaml
@@ -21,6 +21,7 @@ jobs:
           filters: |
             tool:
               - '${{ inputs.tool-directory }}/**'
+              - .github/workflows/reusable-ci.yaml
 
       # Setup
       - name: Checkout repository
@@ -36,7 +37,7 @@ jobs:
       # Linting
       - name: Install golangci-lint
         if: steps.changes.outputs.tool == 'true'
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.3.0
       - name: Lint
         if: steps.changes.outputs.tool == 'true'
         working-directory: ${{ inputs.tool-directory }}

--- a/tools/env-loader/cmd/env-loader_test.go
+++ b/tools/env-loader/cmd/env-loader_test.go
@@ -93,7 +93,8 @@ func TestGetRequestedEnvValues(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	os.Setenv("SOPS_AGE_KEY_FILE", filepath.Join("..", "pkg", "loaders", "testdata", "key1.age"))
+	err := os.Setenv("SOPS_AGE_KEY_FILE", filepath.Join("..", "pkg", "loaders", "testdata", "key1.age"))
+	require.NoError(t, err)
 
 	tests := []struct {
 		desc            string

--- a/tools/env-loader/pkg/loaders/yaml_test.go
+++ b/tools/env-loader/pkg/loaders/yaml_test.go
@@ -236,10 +236,12 @@ func TestSOPSYamlSubloader_GetEnvironmentValues(t *testing.T) {
 		}
 
 		if testCase.ageKeyFileName != "" {
-			os.Setenv(AGE_KEY_ENV_VAR_NAME,
+			err := os.Setenv(AGE_KEY_ENV_VAR_NAME,
 				filepath.Join("testdata", testCase.ageKeyFileName))
+			require.NoError(t, err)
 		} else {
-			os.Unsetenv(AGE_KEY_ENV_VAR_NAME)
+			err := os.Unsetenv(AGE_KEY_ENV_VAR_NAME)
+			require.NoError(t, err)
 		}
 
 		// All output value should be marked as secret. Set this here for

--- a/tools/repo-release-tooling/tooling.mk
+++ b/tools/repo-release-tooling/tooling.mk
@@ -22,7 +22,7 @@ lint:
 	@golangci-lint run ./... -vvv
 
 test:
-	@gotestsum --format github-actions ./... -- -count 100 -shuffle on -timeout 2m -race
+	@gotestsum $(if $(GITHUB_ACTIONS),--format github-actions) ./... -- -count 100 -shuffle on -timeout 2m -race
 
 binary:
 	@echo "Building for $(OS)/$(ARCH) and writing to $(BUILD_DIR)"

--- a/tools/repo-release-tooling/tooling.mk
+++ b/tools/repo-release-tooling/tooling.mk
@@ -19,7 +19,7 @@ print-version:
 	@echo "$(VERSION)"
 
 lint:
-	@golangci-lint run ./... --out-format colored-line-number -vvv
+	@golangci-lint run ./... -vvv
 
 test:
 	@gotestsum --format github-actions ./... -- -count 100 -shuffle on -timeout 2m -race


### PR DESCRIPTION
Remove the `--out-format colored-line-number` as that is no longer
present on golangci-lint 2.0+, and if that later version is installed,
`make lint` fails.

Only pass `--format github-actions` to `gotestsum` if we are running on
GitHub Actions. The output is rather verbose / noisy for locally running
`make test`.

Update golangci-lint from 1.61.0 to 2.3.0 as 1.61.0 does not seem to
properly handle the later (1.23+) versions of Go.

Have the reusable-ci workflow run if that workflow file itself changes,
not just stuff in the tools directory. This makes sure that all tools
are kept up-to-date with the tooling.

Fix newly-surfaced lint errors in amplify-preview and env-loader. Ignore
errors in approvals-service as they are being fixed in another PR.
