### PR TITLE
Approval Service - Improve comment for Deployment Protection Rules decisions

### DIFF
--- a/tools/approval-service/internal/service/releaseservice.go
+++ b/tools/approval-service/internal/service/releaseservice.go
@@ -275,7 +275,7 @@ func (w *ReleaseService) onAccessRequestReviewed(ctx context.Context, req types.
 		return
 	}
 
-	if err := w.ghApprover.handleDecisionForAccessRequestReviewed(ctx, req.GetState(), info.Env, info.WorkflowRunID); err != nil {
+	if err := w.ghApprover.handleDecisionForAccessRequestReviewed(ctx, req, info); err != nil {
 		w.log.Error("Error handling access request reviewed", "access_request_name", req.GetName(), "error", err)
 		return
 	}


### PR DESCRIPTION
Currently the Approval Service will make decisions on Deployment Protection Rules with the comment `Decision made by the approval service based on Access Request state`. This isn't a very useful summary of what occurred.

This PR introduces updates to the comment so that it contains the Access Request ID and the users who approved the Access Request. As an example of the new format: `Access Request "45edb351-a02f-4ecb-9d5d-7e2ec1a91844" was approved by gus.rivera@goteleport.com. This decision was made by the approval service based on Access Request state.`