### PR TITLE
Fixing typo that causes container-image target to produce a slightly malformed image

### DIFF
--- a/tools/repo-release-tooling/tooling.mk
+++ b/tools/repo-release-tooling/tooling.mk
@@ -36,7 +36,7 @@ tarball: binary
 container-image: OS = linux
 container-image: binary
 	@docker buildx build --platform="linux/$(ARCH)" -t "$(TOOL_NAME):$(CONTAINER_VERSION)" \
-		--build-arg "FILE_NAME=$(BINARY_NAME)" --file "$(DOCKERFILE_PATH)" .
+		--build-arg "TOOL_NAME=$(BINARY_NAME)" --file "$(DOCKERFILE_PATH)" .
 
 clean:
 	@rm -rf build/


### PR DESCRIPTION
The Dockerfile declares a build arg `TOOL_NAME` that used to be called `FILE_NAME`. The Makefile target was forgotten when this change was made, so when building a container image locally with the target the `COPY` step will use a different path than expected.

The CD workflow works as expected, this only affects local development when using the `container-image` target.