### PR TITLE
Update bot labels to use devicetrust instead of device-trust

### DIFF
--- a/bot/internal/bot/label.go
+++ b/bot/internal/bot/label.go
@@ -131,7 +131,7 @@ var prefixes = map[string]map[string][]string{
 	},
 	env.TeleportERepo: {
 		"rfd/":             {"rfd"},
-		"lib/devicetrust/": {"device-trust"},
+		"lib/devicetrust/": {"devicetrust"},
 		"lib/idp/saml":     {"application-access", "idp"},
 		"lib/loginrule/":   {"login-rules"},
 		"lib/okta/":        {"application-access"},

--- a/bot/internal/bot/label_test.go
+++ b/bot/internal/bot/label_test.go
@@ -119,7 +119,7 @@ func TestLabel(t *testing.T) {
 					Additions: 1,
 				},
 			},
-			labels: []string{"device-trust", "application-access", string(small)},
+			labels: []string{"devicetrust", "application-access", string(small)},
 		},
 		{
 			desc:   "labels for repo don't exist",


### PR DESCRIPTION
This is consistent with the labels that are applied to issues relating to device trust.

https://github.com/gravitational/teleport/labels?q=device 
https://github.com/gravitational/teleport.e/labels?q=device