### PR TITLE
docpaths: Fix bug in identifying renames

### DIFF
--- a/bot/internal/bot/docpaths.go
+++ b/bot/internal/bot/docpaths.go
@@ -134,9 +134,16 @@ func missingRedirectSources(conf []DocsRedirect, files github.PullRequestFiles) 
 
 		switch f.Status {
 		case "renamed":
-			p := toURLPath(f.PreviousName)
-			if _, ok := sources[p]; !ok {
-				res = append(res, p)
+			currentPath := toURLPath(f.Name)
+			prevPath := toURLPath(f.PreviousName)
+			// This can happen if a category index page was renamed
+			// to a regular page or vice versa.
+			if currentPath == prevPath {
+				continue
+			}
+
+			if _, ok := sources[prevPath]; !ok {
+				res = append(res, prevPath)
 			}
 		case "removed":
 			p := toURLPath(f.Name)

--- a/bot/internal/bot/docpaths_test.go
+++ b/bot/internal/bot/docpaths_test.go
@@ -315,6 +315,30 @@ func TestMissingRedirectSources(t *testing.T) {
 			redirects: []DocsRedirect{},
 			expected:  []string{},
 		},
+		{
+			description: "page renamed to category index",
+			files: []github.PullRequestFile{
+				{
+					Name:         "docs/pages/installation/installation.mdx",
+					PreviousName: "docs/pages/installation.mdx",
+					Status:       "renamed",
+				},
+			},
+			redirects: []DocsRedirect{},
+			expected:  []string{},
+		},
+		{
+			description: "category index renamed to page",
+			files: []github.PullRequestFile{
+				{
+					Name:         "docs/pages/installation.mdx",
+					PreviousName: "docs/pages/installation/installation.mdx",
+					Status:       "renamed",
+				},
+			},
+			redirects: []DocsRedirect{},
+			expected:  []string{},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
The docpaths workflow mis-identifies docs path changes as requiring redirects if those changes rename a regular page to a category index page or vice versa. #380 addressed a similar bug, but assumed that the GitHub API would classify changes that include this kind of renaming as additions and deletions.

However, if the GitHub API classifies this kind of change as a rename, the workflow incorrectly looks up a redirect source, even though the URL path for the category index page is identical to the URL for the regular page.

This change addresses the bug by editing the docpaths workflow to, before checking for a redirect source of a renamed file, ensuring that the previous and current URLs are not actually identical.