### PR TITLE
Setting CGO_ENABLED=0 for our binary builds

### DIFF
--- a/tools/repo-release-tooling/tooling.mk
+++ b/tools/repo-release-tooling/tooling.mk
@@ -27,7 +27,7 @@ test:
 binary:
 	@echo "Building for $(OS)/$(ARCH) and writing to $(BUILD_DIR)"
 	@mkdir -p "$(BUILD_DIR)"
-	@GOOS=$(OS) GOARCH=$(ARCH) go build -o "$(BUILD_DIR)/" -ldflags="-s -w" "$(PACKAGE_PATH)"
+	@CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o "$(BUILD_DIR)/" -ldflags="-s -w" "$(PACKAGE_PATH)"
 
 tarball: TARBALL_NAME = $(TOOL_NAME)-$(VERSION)-$(OS)-$(ARCH).tar.gz
 tarball: binary


### PR DESCRIPTION
This change sets`CGO_ENABLED=0` for our binary builds in the shared tooling Makefile. This should force Go to always build statically linked binaries.

When building linux/amd64 binaries in CD, we would get a dynamically linked binary which would not run on our distroless containers because the C Toolchain is missing. This only affected the linux/amd64 binaries because it was being build on a native host (the runner is also linux/amd64).