### PR TITLE
Simplify docpaths logic and fix a bug

### DIFF
--- a/bot/internal/bot/docpaths_test.go
+++ b/bot/internal/bot/docpaths_test.go
@@ -85,7 +85,7 @@ func TestCheckDocsPathsForMissingRedirects(t *testing.T) {
 						files: []github.PullRequestFile{
 							{
 								Name:         "docs/pages/enroll-resources/database-access/get-started.mdx",
-								Status:       "renamed",
+								Status:       github.StatusRenamed,
 								PreviousName: "docs/pages/database-access/get-started.mdx",
 							},
 						},
@@ -117,7 +117,7 @@ func TestMissingRedirectSources(t *testing.T) {
 					Name:         "docs/pages/databases/protect-mysql.mdx",
 					Additions:    0,
 					Deletions:    0,
-					Status:       "renamed",
+					Status:       github.StatusRenamed,
 					PreviousName: "docs/pages/databases/mysql.mdx",
 				},
 			},
@@ -137,7 +137,7 @@ func TestMissingRedirectSources(t *testing.T) {
 					Name:         "docs/pages/databases/protect-mysql.mdx",
 					Additions:    0,
 					Deletions:    0,
-					Status:       "renamed",
+					Status:       github.StatusRenamed,
 					PreviousName: "docs/pages/databases/mysql.mdx",
 				},
 			},
@@ -151,7 +151,7 @@ func TestMissingRedirectSources(t *testing.T) {
 					Name:      "docs/pages/databases/mysql.mdx",
 					Additions: 0,
 					Deletions: 0,
-					Status:    "removed",
+					Status:    github.StatusRemoved,
 				},
 			},
 			redirects: []DocsRedirect{
@@ -169,7 +169,7 @@ func TestMissingRedirectSources(t *testing.T) {
 					Name:      "docs/pages/databases/mysql.mdx",
 					Additions: 0,
 					Deletions: 200,
-					Status:    "removed",
+					Status:    github.StatusRemoved,
 				},
 			},
 			redirects: []DocsRedirect{},
@@ -182,7 +182,7 @@ func TestMissingRedirectSources(t *testing.T) {
 					Name:      "docs/pages/databases/mysql.mdx",
 					Additions: 50,
 					Deletions: 15,
-					Status:    "modified",
+					Status:    github.StatusModified,
 				},
 			},
 			redirects: []DocsRedirect{},
@@ -195,7 +195,7 @@ func TestMissingRedirectSources(t *testing.T) {
 					Name:         "docs/pages/databases/protect-mysql.mdx",
 					Additions:    0,
 					Deletions:    0,
-					Status:       "renamed",
+					Status:       github.StatusRenamed,
 					PreviousName: "docs/pages/databases/mysql.mdx",
 				},
 			},
@@ -224,7 +224,7 @@ func TestMissingRedirectSources(t *testing.T) {
 					Name:         "docs/pages/enroll-resources/databases/databases.mdx",
 					Additions:    0,
 					Deletions:    0,
-					Status:       "renamed",
+					Status:       github.StatusRenamed,
 					PreviousName: "docs/pages/databases/databases.mdx",
 				},
 			},
@@ -244,7 +244,7 @@ func TestMissingRedirectSources(t *testing.T) {
 					Name:         "docs/pages/enroll-resources/applications/applications.mdx",
 					Additions:    0,
 					Deletions:    0,
-					Status:       "renamed",
+					Status:       github.StatusRenamed,
 					PreviousName: "docs/pages/applications/applications.mdx",
 				},
 			},
@@ -264,7 +264,7 @@ func TestMissingRedirectSources(t *testing.T) {
 					Name:         "docs/pages/includes/databases/mysql-certs.mdx",
 					Additions:    0,
 					Deletions:    0,
-					Status:       "renamed",
+					Status:       github.StatusRenamed,
 					PreviousName: "docs/pages/includes/databases/mysql.mdx",
 				},
 			},
@@ -278,7 +278,7 @@ func TestMissingRedirectSources(t *testing.T) {
 					Name:         "docs/pages/connect-your-client/includes/mysql-certs.mdx",
 					Additions:    0,
 					Deletions:    0,
-					Status:       "renamed",
+					Status:       github.StatusRenamed,
 					PreviousName: "docs/pages/connect-your-client/includes/mysql.mdx",
 				},
 			},
@@ -290,11 +290,11 @@ func TestMissingRedirectSources(t *testing.T) {
 			files: []github.PullRequestFile{
 				{
 					Name:   "docs/pages/installation.mdx",
-					Status: "removed",
+					Status: github.StatusRemoved,
 				},
 				{
 					Name:   "docs/pages/installation/installation.mdx",
-					Status: "added",
+					Status: github.StatusAdded,
 				},
 			},
 			redirects: []DocsRedirect{},
@@ -305,11 +305,11 @@ func TestMissingRedirectSources(t *testing.T) {
 			files: []github.PullRequestFile{
 				{
 					Name:   "docs/pages/installation.mdx",
-					Status: "added",
+					Status: github.StatusAdded,
 				},
 				{
 					Name:   "docs/pages/installation/installation.mdx",
-					Status: "removed",
+					Status: github.StatusRemoved,
 				},
 			},
 			redirects: []DocsRedirect{},
@@ -321,7 +321,7 @@ func TestMissingRedirectSources(t *testing.T) {
 				{
 					Name:         "docs/pages/installation/installation.mdx",
 					PreviousName: "docs/pages/installation.mdx",
-					Status:       "renamed",
+					Status:       github.StatusRenamed,
 				},
 			},
 			redirects: []DocsRedirect{},
@@ -333,11 +333,33 @@ func TestMissingRedirectSources(t *testing.T) {
 				{
 					Name:         "docs/pages/installation.mdx",
 					PreviousName: "docs/pages/installation/installation.mdx",
-					Status:       "renamed",
+					Status:       github.StatusRenamed,
 				},
 			},
 			redirects: []DocsRedirect{},
 			expected:  []string{},
+		},
+		{
+			description: "complex rename scenario",
+			files: []github.PullRequestFile{
+				{
+					Name:         "docs/pages/identity-governance/access-lists.mdx",
+					PreviousName: "docs/pages/identity-governance/access-lists/guide.mdx",
+					Status:       github.StatusRenamed,
+				},
+				{
+					Name:   "docs/pages/identity-governance/access-lists/access-lists.mdx",
+					Status: github.StatusRemoved,
+				},
+			},
+			redirects: []DocsRedirect{
+				{
+					Source:      "/identity-governance/access-lists/guide/",
+					Destination: "/identity-governance/access-lists/",
+					Permanent:   true,
+				},
+			},
+			expected: []string{},
 		},
 	}
 

--- a/bot/internal/bot/verify.go
+++ b/bot/internal/bot/verify.go
@@ -79,7 +79,7 @@ func (b *Bot) verifyDBMigration(ctx context.Context, pathPrefix string) error {
 
 	// don't evaluate removed files
 	prFiles = filterSlice(prFiles, func(f github.PullRequestFile) bool {
-		return f.Status != "removed"
+		return f.Status != github.StatusRemoved
 	})
 
 	// parse PR migration file ids

--- a/bot/internal/bot/verify_test.go
+++ b/bot/internal/bot/verify_test.go
@@ -97,7 +97,7 @@ func TestParseMigrationFileIDs(t *testing.T) {
 }
 
 func TestVerifyCloudDBMigration(t *testing.T) {
-	const defaultStatus = "added"
+	const defaultStatus = github.StatusAdded
 
 	// load fake github with noop data
 	fgh := &fakeGithub{ref: github.Reference{Name: "foo", SHA: "abc"}}
@@ -116,7 +116,7 @@ func TestVerifyCloudDBMigration(t *testing.T) {
 	cases := []struct {
 		prFiles     []string
 		branchFiles []string
-		status      string
+		status      github.FileStatus
 		expectErr   bool
 	}{
 		{}, // 0    no migration files in branch or pr
@@ -150,7 +150,7 @@ func TestVerifyCloudDBMigration(t *testing.T) {
 			expectErr: true,
 		},
 		{ // 5 OK   filter removed files
-			status: "removed",
+			status: github.StatusRemoved,
 			prFiles: []string{
 				"db/202301031501_fake.up.sql",
 			},
@@ -171,7 +171,7 @@ func TestVerifyCloudDBMigration(t *testing.T) {
 	}
 	fghBaseline := *fgh
 	for i, test := range cases {
-		if test.status == "" {
+		if test.status == github.StatusUnknown {
 			test.status = defaultStatus
 		}
 		for _, f := range test.prFiles {

--- a/bot/internal/github/github.go
+++ b/bot/internal/github/github.go
@@ -242,6 +242,48 @@ func (c *Client) ListReviewers(ctx context.Context, organization string, reposit
 	return reviewers, nil
 }
 
+// FileStatus indicates the operation that led to the current state of the file,
+// based on the value reported by the GitHub API.
+type FileStatus int
+
+const (
+	StatusUnknown FileStatus = iota
+	StatusAdded
+	StatusRemoved
+	StatusModified
+	StatusRenamed
+	StatusCopied
+	StatusChanged
+	StatusUnchanged
+)
+
+// fileStatusFromLabel retrieves the FileStatus that corresponds to the label
+// returned by the GitHub API. Status is either added, removed, modified,
+// renamed, copied, changed, unchanged.
+//
+// See response schema for the current list of statuses:
+// https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files
+func fileStatusFromLabel(name string) FileStatus {
+	switch name {
+	case "added":
+		return StatusAdded
+	case "removed":
+		return StatusRemoved
+	case "modified":
+		return StatusModified
+	case "renamed":
+		return StatusRenamed
+	case "copied":
+		return StatusCopied
+	case "changed":
+		return StatusChanged
+	case "unchanged":
+		return StatusUnchanged
+	default:
+		return StatusUnknown
+	}
+}
+
 // PullRequestFile is a file that was modified in a pull request.
 type PullRequestFile struct {
 	// Name is the name of the file.
@@ -250,10 +292,7 @@ type PullRequestFile struct {
 	Additions int
 	// Deletions is the number of lines removed from the file
 	Deletions int
-	// Status is either added, removed, modified, renamed, copied, changed, unchanged
-	// See response schema for the current list of statuses:
-	// https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files
-	Status string
+	Status    FileStatus
 	// PreviousName is the name of the file prior to renaming. The GitHub
 	// API only assigns this if Status is "renamed". For deleted files, the
 	// GitHub API uses Name.
@@ -419,7 +458,7 @@ func (c *Client) ListFiles(ctx context.Context, organization string, repository 
 				Name:         file.GetFilename(),
 				Additions:    file.GetAdditions(),
 				Deletions:    file.GetDeletions(),
-				Status:       file.GetStatus(),
+				Status:       fileStatusFromLabel(file.GetStatus()),
 				PreviousName: file.GetPreviousFilename(),
 			})
 		}


### PR DESCRIPTION
Currently, the docpaths workflow addresses a corner case in which GitHub marks a file rename as a deletion and an addition. However, there are other possible ways GitHub may classify file renames. For example, if we rename Page A to Page B, and incorporate content from Page C into Page B, the GitHub API may mark Page A as a deletion and Page B as a rename from Page C (rather than an addition).

As a result, in more complex renaming scenarios (e.g., gravitational/teleport#59329), the docpaths workflow can require that the author add a redirect from a file that already exists, i.e., an invalid redirect from one path to the same path.

This change accommodates these more complex rename scenarios. The docpaths workflow checks if the path to check (the previous filename for a renamed file or the filename for a deleted file) corresponds to a file introduced by the PR, without assuming that this would be due to a specific scenario.

Also use an enum for GitHub file statuses to prevent typos in string values from introducing bugs.