### PR TITLE
Add RFD branch validation to the bot

### DIFF
--- a/bot/internal/bot/rfd.go
+++ b/bot/internal/bot/rfd.go
@@ -1,0 +1,70 @@
+package bot
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+	"github.com/gravitational/trace"
+)
+
+// ValidateNewRFD ensures that PRs which add **new** RFDs follow
+// the process laid out in [RFD 0](https://github.com/gravitational/teleport/blob/61ed36979ecb98310c853a6535108f57464cbef2/rfd/0000-rfds.md).
+// Namely, this ensures that
+// - All branches are in the form rfd/$number-your-title
+// - The RFD itself exists at /rfd/$number-your-title.md
+// - All RFD numbers are properly zero padded to avoid collisions (rfd/123-foo vs. rfd/0123-bar)
+func (b *Bot) ValidateNewRFD(ctx context.Context) error {
+	files, err := b.c.GitHub.ListFiles(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		b.c.Environment.Number)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	branchRegexp := regexp.MustCompile(`^rfd\/(\d+)-`)
+	matches := branchRegexp.FindStringSubmatch(b.c.Environment.UnsafeHead)
+	isRFDBranch := len(matches) == 2
+
+	var hasValidRFD bool
+	for _, file := range files {
+		if file.Status != github.StatusAdded {
+			continue
+		}
+
+		if strings.HasPrefix(file.Name, "rfd/assets/") || !strings.HasPrefix(file.Name, "rfd/") {
+			continue
+		}
+
+		if !isRFDBranch {
+			return trace.BadParameter("RFD branches must follow the pattern rfd/$number-your-title")
+		}
+
+		if file.Name != b.c.Environment.UnsafeHead+".md" {
+			return trace.BadParameter("Found RFD named %q, expected RFD to be named %q", file.Name, b.c.Environment.UnsafeHead+".md")
+		}
+
+		rfdNumberString := matches[1]
+		rfdNumber, err := strconv.Atoi(rfdNumberString)
+		if err != nil {
+			return trace.BadParameter("RFD number %q is not a valid number", rfdNumberString)
+		}
+
+		expectedNumber := fmt.Sprintf("%04d", rfdNumber)
+		if expectedNumber != rfdNumberString {
+			return trace.BadParameter("Found branch named %q, expected branch to be named %q", b.c.Environment.UnsafeHead, "rfd/"+expectedNumber+b.c.Environment.UnsafeHead[4+len(rfdNumberString):])
+		}
+
+		hasValidRFD = true
+	}
+
+	if isRFDBranch && !hasValidRFD {
+		return trace.BadParameter("RFD %q is missing", b.c.Environment.UnsafeHead+".md")
+	}
+
+	return nil
+}

--- a/bot/internal/bot/rfd_test.go
+++ b/bot/internal/bot/rfd_test.go
@@ -1,0 +1,194 @@
+package bot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/shared-workflows/bot/internal/env"
+	"github.com/gravitational/shared-workflows/bot/internal/github"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateNewRFD(t *testing.T) {
+
+	tests := []struct {
+		desc         string
+		branch       string
+		files        []github.PullRequestFile
+		errorMessage string
+	}{
+		{
+			desc:   "code-only",
+			branch: "foo",
+			files: []github.PullRequestFile{
+				{
+					Name:   "file.go",
+					Status: github.StatusAdded,
+				},
+				{
+					Name:   "examples/README.md",
+					Status: github.StatusChanged,
+				},
+			},
+		},
+		{
+			desc:   "valid-rfd",
+			branch: "rfd/0001-test-123",
+			files: []github.PullRequestFile{
+				{
+					Name:   "rfd/0001-test-123.md",
+					Status: github.StatusAdded,
+				},
+			},
+		},
+		{
+			desc:   "rfd-branch-assets-only",
+			branch: "rfd/0001-test-123",
+			files: []github.PullRequestFile{
+				{
+					Name:   "rfd/assets/0001-test-123.png",
+					Status: github.StatusAdded,
+				},
+			},
+			errorMessage: `RFD "rfd/0001-test-123.md" is missing`,
+		},
+		{
+			desc:   "random-branch-rfd-assets-only",
+			branch: "rjones/test-123",
+			files: []github.PullRequestFile{
+				{
+					Name:   "rfd/assets/0001-test-123.png",
+					Status: github.StatusAdded,
+				},
+			},
+		},
+		{
+			desc:   "invalid-rfd-branch",
+			branch: "rjones/rfd-0001-test-123",
+			files: []github.PullRequestFile{
+				{
+					Name:   "rfd/0001-test-123.md",
+					Status: github.StatusAdded,
+				},
+			},
+			errorMessage: "RFD branches must follow the pattern rfd/$number-your-title",
+		},
+		{
+			desc:   "invalid-rfd-name",
+			branch: "rfd/0001-test-123",
+			files: []github.PullRequestFile{
+				{
+					Name:   "rfd/test-123.md",
+					Status: github.StatusAdded,
+				},
+			},
+			errorMessage: `Found RFD named "rfd/test-123.md", expected RFD to be named "rfd/0001-test-123.md"`,
+		},
+		{
+			desc:   "missing-rfd",
+			branch: "rfd/0001-test-123",
+			files: []github.PullRequestFile{
+				{
+					Name:   "file.go",
+					Status: github.StatusAdded,
+				},
+				{
+					Name:   "examples/README.md",
+					Status: github.StatusAdded,
+				},
+			},
+			errorMessage: `RFD "rfd/0001-test-123.md" is missing`,
+		},
+		{
+			desc:   "deleting-rfd",
+			branch: "rjones/remove_rfd",
+			files: []github.PullRequestFile{
+				{
+					Name:   "rfd/0001-test-123.md",
+					Status: github.StatusRemoved,
+				},
+			},
+		},
+		{
+			desc:   "copied-rfd",
+			branch: "rjones/remove_rfd",
+			files: []github.PullRequestFile{
+				{
+					Name:   "rfd/0001-test-123.md",
+					Status: github.StatusCopied,
+				},
+			},
+		},
+		{
+			desc:   "modified-rfd",
+			branch: "rjones/remove_rfd",
+			files: []github.PullRequestFile{
+				{
+					Name:   "rfd/0001-test-123.md",
+					Status: github.StatusModified,
+				},
+			},
+		},
+		{
+			desc:   "renamed-rfd",
+			branch: "rjones/remove_rfd",
+			files: []github.PullRequestFile{
+				{
+					Name:   "rfd/0001-test-123.md",
+					Status: github.StatusRenamed,
+				},
+			},
+		},
+		{
+			desc:   "multiple-rfds",
+			branch: "rfd/0001-test-123",
+			files: []github.PullRequestFile{
+				{
+					Name:   "rfd/0001-test-123.md",
+					Status: github.StatusAdded,
+				},
+				{
+					Name:   "rfd/0002-test-124.md",
+					Status: github.StatusAdded,
+				},
+			},
+			errorMessage: `Found RFD named "rfd/0002-test-124.md", expected RFD to be named "rfd/0001-test-123.md"`,
+		},
+		{
+			desc:   "rfd-number-padding",
+			branch: "rfd/1-test-123",
+			files: []github.PullRequestFile{
+				{
+					Name:   "rfd/1-test-123.md",
+					Status: github.StatusAdded,
+				},
+			},
+			errorMessage: `Found branch named "rfd/1-test-123", expected branch to be named "rfd/0001-test-123"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			b := &Bot{
+				c: &Config{
+					Environment: &env.Environment{
+						Organization: "foo",
+						Repository:   "test",
+						UnsafeHead:   test.branch,
+					},
+					GitHub: &fakeGithub{
+						files: test.files,
+					},
+				},
+			}
+
+			err := b.ValidateNewRFD(context.Background())
+			if test.errorMessage == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorContains(t, err, test.errorMessage)
+		})
+	}
+}

--- a/bot/main.go
+++ b/bot/main.go
@@ -82,6 +82,8 @@ func main() {
 		err = b.CheckChangelog(ctx)
 	case "docpaths":
 		err = b.CheckDocsPathsForMissingRedirects(ctx, flags.teleportClonePath)
+	case "rfd":
+		err = b.ValidateNewRFD(ctx)
 	default:
 		err = trace.BadParameter("unknown workflow: %v", flags.workflow)
 	}
@@ -122,7 +124,7 @@ type flags struct {
 
 func parseFlags() (flags, error) {
 	var (
-		workflow          = flag.String("workflow", "", "specific workflow to run [assign, check, dismiss, backport]")
+		workflow          = flag.String("workflow", "", "specific workflow to run [assign, check, dismiss, label, backport, verify, exclude-flakes, binary-sizes, bloat, changelog, docpaths, rfd]")
 		token             = flag.String("token", "", "GitHub authentication token")
 		reviewers         = flag.String("reviewers", "", "reviewer assignments")
 		local             = flag.Bool("local", false, "local workflow dry run")


### PR DESCRIPTION
### What

The new `rfd` workflow validates that PRs which introduce a new RFD adhere to the following rules laid out in [RFD 0](https://github.com/gravitational/teleport/blob/61ed36979ecb98310c853a6535108f57464cbef2/rfd/0000-rfds.md).

- All RFD branches must be in the form rfd/$number-your-title
- The RFD exists at /rfd/$number-your-title.md
- All RFD numbers are properly zero padded to avoid collisions (rfd/123-foo vs. rfd/0123-bar)


Any PRs which modify existing RFDs are ignored. Any files added to rfd/assets are ignored.


### Why

The motivation for this change can be seen in https://github.com/gravitational/teleport/pull/59141. The PR correctly followed the guidance in RFD 0 and was created on branch `rfd/0224-in-band-mfa-ssh-sessions`. However, https://github.com/gravitational/teleport/pull/58824 also tried to follow the guidance but used a different format (`rfd/224-ec2-discovery-multiagent`), was merged prior to https://github.com/gravitational/teleport/pull/59141 and is now RFD 224. We can now either proceed with multiple RFD 224, or https://github.com/gravitational/teleport/pull/59141 can try squatting on a new number in hopes that the same doesn't happen again.