### PR TITLE
updating Approval Service semantic version to pick up TTL event cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 go.work*
+
+# editors
+.idea/

--- a/tools/approval-service/Makefile
+++ b/tools/approval-service/Makefile
@@ -1,6 +1,6 @@
 TOOL_NAME = approval-service
 PACKAGE_PATH = ./cmd/approval-service.go
-VERSION = v0.1.0
+VERSION = v0.1.1
 
 
 include ../repo-release-tooling/tooling.mk


### PR DESCRIPTION
This semantic version update picks up https://github.com/gravitational/shared-workflows/pull/414

Adding .idea to git ignore to avoid intellij / Goland IDEA config files.