### PR TITLE
Various enhancements to the GitHub Library to support our Temporal platform

### DIFF
--- a/libs/github/github.go
+++ b/libs/github/github.go
@@ -38,8 +38,8 @@ const (
 
 type Client struct {
 	appTransport *installationAuthTransport
-	client *go_github.Client
-	search searchService
+	client       *go_github.Client
+	search       searchService
 }
 
 type searchService interface {
@@ -58,8 +58,6 @@ func New(ctx context.Context, token string) (*Client, error) {
 	}, nil
 }
 
-type NewForAppOptions func()
-
 // NewForApp returns a new GitHub Client with authentication for a GitHub App.
 func NewForApp(ctx context.Context, appID int64, installationID int64, privateKey []byte) (*Client, error) {
 	appTr, err := newAppTransport(ctx, appID, installationID, privateKey)
@@ -74,13 +72,13 @@ func NewForApp(ctx context.Context, appID int64, installationID int64, privateKe
 	cl := go_github.NewClient(httpClient)
 	return &Client{
 		appTransport: appTr,
-		client: cl,
-		search: cl.Search,
+		client:       cl,
+		search:       cl.Search,
 	}, nil
 }
 
 // GetAppOAuthToken returns the current OAuth token for the GitHub App installation.
-// This is useful for cases where you want to use the token outside of the GitHub client, 
+// This is useful for cases where you want to use the token outside of the GitHub client,
 // such as in API requests made by other tooling (ie git) or for debugging purposes.
 func (c *Client) GetAppOAuthToken(ctx context.Context) (string, error) {
 	if c.appTransport == nil {

--- a/libs/github/github.go
+++ b/libs/github/github.go
@@ -37,6 +37,7 @@ const (
 )
 
 type Client struct {
+	appTransport *installationAuthTransport
 	client *go_github.Client
 	search searchService
 }
@@ -57,6 +58,8 @@ func New(ctx context.Context, token string) (*Client, error) {
 	}, nil
 }
 
+type NewForAppOptions func()
+
 // NewForApp returns a new GitHub Client with authentication for a GitHub App.
 func NewForApp(ctx context.Context, appID int64, installationID int64, privateKey []byte) (*Client, error) {
 	appTr, err := newAppTransport(ctx, appID, installationID, privateKey)
@@ -70,9 +73,25 @@ func NewForApp(ctx context.Context, appID int64, installationID int64, privateKe
 
 	cl := go_github.NewClient(httpClient)
 	return &Client{
+		appTransport: appTr,
 		client: cl,
 		search: cl.Search,
 	}, nil
+}
+
+// GetAppOAuthToken returns the current OAuth token for the GitHub App installation.
+// This is useful for cases where you want to use the token outside of the GitHub client, 
+// such as in API requests made by other tooling (ie git) or for debugging purposes.
+func (c *Client) GetAppOAuthToken(ctx context.Context) (string, error) {
+	if c.appTransport == nil {
+		return "", fmt.Errorf("client is not configured for GitHub App authentication")
+	}
+
+	token, err := c.appTransport.getAccessToken(ctx)
+	if err != nil {
+		return "", fmt.Errorf("getting access token from transport: %w", err)
+	}
+	return token, nil
 }
 
 // installationAuthTransport is a middleware that adds GitHub App authentication to HTTP requests.

--- a/libs/github/workflow.go
+++ b/libs/github/workflow.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	go_github "github.com/google/go-github/v84/github"
 )
@@ -47,6 +48,13 @@ type WorkflowRunInfo struct {
 	// Conclusion is the conclusion of the workflow run (only set when status is "completed").
 	// GitHub's Workflow API uses check run conclusions for workflow runs.
 	Conclusion CheckConclusion
+	// Duration is the total time taken for the workflow since it was created til it was last updated.
+	// This is useful for tracking how long workflows are taking to run and can be used for performance monitoring or debugging.
+	Duration time.Duration
+	// RunDuration is the time taken for the workflow since it was last run til it was last updated. 
+	// This tracks the current attempt of the workflow run, so if a workflow run is retried or has multiple attempts, 
+	// this will reflect the duration of the current attempt rather than the total duration since creation.
+	RunDuration time.Duration
 }
 
 // GetWorkflowRunInfo retrieves information about a specific workflow run by its ID.
@@ -152,14 +160,17 @@ func (e *WorkflowRunNotFoundError) Error() string {
 	return e.Message
 }
 
-func newWorkflowRunNotFoundError(message string) *WorkflowRunNotFoundError {
-	return &WorkflowRunNotFoundError{
-		Message: message,
-	}
-}
-
 // workflowRunInfoFromObj converts a [go_github.WorkflowRun] object to a [WorkflowRunInfo].
 func workflowRunInfoFromObj(githubObj *go_github.WorkflowRun) WorkflowRunInfo {
+	// UpdatedAt is the timestamp of the last event that occurred for the workflow run, such as it being created, started, completed, or updated.
+	// This is the most reliable timestamp for calculating durations because it is updated whenever the workflow run is updated in any way. 
+	updatedAt := githubObj.GetUpdatedAt()
+	// CreatedAt is the timestamp of when the initial workflow run was created.
+	createdAt := githubObj.GetCreatedAt()
+	// RunStartedAt is the timestamp of when the workflow run was started. This is typically when the workflow run starts executing.
+	// This is also updated if a workflow run is retried, so it reflects the start time of the current attempt of the workflow run.
+	runStartedAt := githubObj.GetRunStartedAt()
+
 	return WorkflowRunInfo{
 		WorkflowID:   githubObj.GetID(),
 		Name:         githubObj.GetName(),
@@ -169,6 +180,8 @@ func workflowRunInfoFromObj(githubObj *go_github.WorkflowRun) WorkflowRunInfo {
 		Repository:   githubObj.GetRepository().GetName(),
 		Status:       CheckStatus(githubObj.GetStatus()),
 		Conclusion:   CheckConclusion(githubObj.GetConclusion()),
+		Duration:     updatedAt.Sub(createdAt.Time),
+		RunDuration:  updatedAt.Sub(runStartedAt.Time),
 	}
 }
 
@@ -180,5 +193,6 @@ func (w WorkflowRunInfo) LogValue() slog.Value {
 		slog.Int64("workflow_id", w.WorkflowID),
 		slog.String("status", w.Status.String()),
 		slog.String("conclusion", w.Conclusion.String()),
+		slog.String("duration", w.Duration.String()),
 	)
 }

--- a/libs/github/workflow.go
+++ b/libs/github/workflow.go
@@ -51,8 +51,8 @@ type WorkflowRunInfo struct {
 	// Duration is the total time taken for the workflow since it was created til it was last updated.
 	// This is useful for tracking how long workflows are taking to run and can be used for performance monitoring or debugging.
 	Duration time.Duration
-	// RunDuration is the time taken for the workflow since it was last run til it was last updated. 
-	// This tracks the current attempt of the workflow run, so if a workflow run is retried or has multiple attempts, 
+	// RunDuration is the time taken for the workflow since it was last run til it was last updated.
+	// This tracks the current attempt of the workflow run, so if a workflow run is retried or has multiple attempts,
 	// this will reflect the duration of the current attempt rather than the total duration since creation.
 	RunDuration time.Duration
 }
@@ -163,7 +163,7 @@ func (e *WorkflowRunNotFoundError) Error() string {
 // workflowRunInfoFromObj converts a [go_github.WorkflowRun] object to a [WorkflowRunInfo].
 func workflowRunInfoFromObj(githubObj *go_github.WorkflowRun) WorkflowRunInfo {
 	// UpdatedAt is the timestamp of the last event that occurred for the workflow run, such as it being created, started, completed, or updated.
-	// This is the most reliable timestamp for calculating durations because it is updated whenever the workflow run is updated in any way. 
+	// This is the most reliable timestamp for calculating durations because it is updated whenever the workflow run is updated in any way.
 	updatedAt := githubObj.GetUpdatedAt()
 	// CreatedAt is the timestamp of when the initial workflow run was created.
 	createdAt := githubObj.GetCreatedAt()

--- a/libs/github/workflow.go
+++ b/libs/github/workflow.go
@@ -96,6 +96,8 @@ type WorkflowDispatchResult struct {
 	// WorkflowRunID is the ID of the resulting workflow.
 	// You can use [GetWorkflowRunInfo] to query for more info.
 	WorkflowRunID int64
+	// HTMLURL is the URL to view the workflow run on GitHub.
+	HTMLURL string
 }
 
 // WorkflowDispatch triggers a workflow dispatch event.
@@ -121,7 +123,21 @@ func (c *Client) WorkflowDispatch(ctx context.Context, org, repo string, req Wor
 
 	return WorkflowDispatchResult{
 		WorkflowRunID: result.GetWorkflowRunID(),
+		HTMLURL:       result.GetHTMLURL(),
 	}, nil
+}
+
+// RerunWorkflowFailedJobs triggers a rerun of all failed jobs in a workflow run.
+// This is useful for workflows that have failed due to transient errors and do not require a full re-dispatch.
+func (c *Client) RerunWorkflowFailedJobs(ctx context.Context, org, repo string, runID int64) error {
+	if runID == 0 {
+		return fmt.Errorf("runID is required")
+	}
+	_, err := c.client.Actions.RerunFailedJobsByID(ctx, org, repo, runID)
+	if err != nil {
+		return fmt.Errorf("RerunFailedJobsByID API call: %w", err)
+	}
+	return nil
 }
 
 // WorkflowRunNotFoundError is a sentinel error returned when a workflow run cannot be found.

--- a/libs/github/workflows_test.go
+++ b/libs/github/workflows_test.go
@@ -94,28 +94,28 @@ func TestWorkflowDispatch(t *testing.T) {
 
 func TestRerunWorkflowFailedJobs(t *testing.T) {
 	tests := []struct {
-		name         string
+		name          string
 		workflowRunID int64
-		mockStatus   int
-		wantError    bool
+		mockStatus    int
+		wantError     bool
 	}{
 		{
-			name:         "happy path",
+			name:          "happy path",
 			workflowRunID: 22638542196,
-			mockStatus:   http.StatusOK,
-			wantError:    false,
+			mockStatus:    http.StatusOK,
+			wantError:     false,
 		},
 		{
-			name:         "API error",
+			name:          "API error",
 			workflowRunID: 22638542196,
-			mockStatus:   http.StatusInternalServerError,
-			wantError:    true,
+			mockStatus:    http.StatusInternalServerError,
+			wantError:     true,
 		},
 		{
-			name:         "missing workflow run ID",
+			name:          "missing workflow run ID",
 			workflowRunID: 0,
-			mockStatus:   http.StatusInternalServerError,
-			wantError:    true,
+			mockStatus:    http.StatusInternalServerError,
+			wantError:     true,
 		},
 	}
 

--- a/libs/github/workflows_test.go
+++ b/libs/github/workflows_test.go
@@ -15,6 +15,7 @@ func TestWorkflowDispatch(t *testing.T) {
 		mockStatus     int
 		wantError      bool
 		wantWorkflowID int64
+		wantHTMLURL    string
 	}{
 		{
 			name:           "happy path",
@@ -25,6 +26,7 @@ func TestWorkflowDispatch(t *testing.T) {
 			mockStatus:     http.StatusOK,
 			wantError:      false,
 			wantWorkflowID: 22638542196,
+			wantHTMLURL:    "https://github.com/gravitational/test-workflows/actions/runs/22638542196",
 		},
 		{
 			name:         "missing workflow name",
@@ -81,6 +83,65 @@ func TestWorkflowDispatch(t *testing.T) {
 				}
 				if result.WorkflowRunID != tt.wantWorkflowID {
 					t.Errorf("expected workflow run ID %d, got %d", tt.wantWorkflowID, result.WorkflowRunID)
+				}
+				if result.HTMLURL != tt.wantHTMLURL {
+					t.Errorf("expected HTML URL %s, got %s", tt.wantHTMLURL, result.HTMLURL)
+				}
+			}
+		})
+	}
+}
+
+func TestRerunWorkflowFailedJobs(t *testing.T) {
+	tests := []struct {
+		name         string
+		workflowRunID int64
+		mockStatus   int
+		wantError    bool
+	}{
+		{
+			name:         "happy path",
+			workflowRunID: 22638542196,
+			mockStatus:   http.StatusOK,
+			wantError:    false,
+		},
+		{
+			name:         "API error",
+			workflowRunID: 22638542196,
+			mockStatus:   http.StatusInternalServerError,
+			wantError:    true,
+		},
+		{
+			name:         "missing workflow run ID",
+			workflowRunID: 0,
+			mockStatus:   http.StatusInternalServerError,
+			wantError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs", func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST request, got %s", r.Method)
+				}
+				w.WriteHeader(tt.mockStatus)
+			})
+
+			client, closer := newFakeClient(mux)
+			t.Cleanup(closer)
+
+			ctx := t.Context()
+			err := client.RerunWorkflowFailedJobs(ctx, "gravitational", "example-repo", tt.workflowRunID)
+
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
 				}
 			}
 		})


### PR DESCRIPTION
This introduces four enhancements to the GitHub library that will be useful for our Temporal work.
* Returning the HTML URL is useless for other libraries to rely on which is why it wasn't originally included. However it is good for enhancing user experience and for debugging when trying to track down a failed job.
* Rerunning failed workflows has been added to allow for recovery of transient failures. Temporal can orchestrate this to recover from transient failures in workflows.
* The GitHub App client now has a helper method to obtain the currently active OAuth token. This will be useful when our Temporal work needs to interact with Git directly (cloning `teleport.e`) which needs a valid token to authenticate with.
* Duration is returned in WorkflowInfo. This will be used in our Temporal workflow to bubble up metrics related to GitHub Actions performance.