### PR TITLE
Change command to get timestamp for reference

### DIFF
--- a/libs/git/git.go
+++ b/libs/git/git.go
@@ -57,7 +57,7 @@ func (r *Repo) BranchNameForHead() (string, error) {
 // TimestampForRef will get the timestamp for the given reference.
 // Will work for symbolic references such as tags, HEAD, branches
 func (r *Repo) TimestampForRef(ref string) (time.Time, error) {
-	t, err := r.RunCmd("show", "-s", "--format=%cI", ref)
+	t, err := r.RunCmd("log", "-1", "--format=%cI", ref)
 	if err != nil {
 		return time.Time{}, trace.Wrap(err, trace.BadParameter("can't get timestamp for ref: %q", ref))
 	}


### PR DESCRIPTION
`git show` returns a bunch of extra information when evaluating signed refs. Use `git log` to get just the time as expected.