### PR TITLE
Refactoring changelog tool to support monorepo

### DIFF
--- a/tools/changelog/Makefile
+++ b/tools/changelog/Makefile
@@ -1,4 +1,4 @@
 TOOL_NAME = changelog
-VERSION = v1.0.7
+VERSION = v1.1.0
 
 include ../repo-release-tooling/tooling.mk

--- a/tools/changelog/changelog.go
+++ b/tools/changelog/changelog.go
@@ -17,11 +17,9 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"context"
 	"regexp"
 	"strings"
-	"text/template"
 	"time"
 	"unicode"
 
@@ -35,38 +33,42 @@ type changelogInfo struct {
 	Summary string
 	Number  int
 	URL     string
+	// IsEnterprise indicates if the changelog is for an enterprise feature
+	IsEnterprise bool
 }
-
-const (
-	clTemplate = `
-{{- range . -}}
-* {{.Summary}} [#{{.Number}}]({{.URL}})
-{{ end -}}
-`
-	clTemplateNoLink = `
-{{- range . -}}
-* {{.Summary}}
-{{ end -}}
-`
-)
 
 var (
 	// clPattern will match a changelog format with the summary as a subgroup.
 	// e.g. will match a line "changelog: this is a changelog" with subgroup "this is a changelog".
 	clPattern = regexp.MustCompile(`[Cc]hangelog: +(.*)`)
-
-	clParsedTmpl       = template.Must(template.New("cl").Parse(clTemplate))
-	clParsedTmplNoLink = template.Must(template.New("cl").Parse(clTemplateNoLink))
+	// entCLPattern will match an enterprise changelog format with the summary as a subgroup.
+	// e.g. will match a line "changelog-enterprise: this is an enterprise changelog" with subgroup "this is an enterprise changelog".
+	entCLPattern = regexp.MustCompile(`[Cc]hangelog-[Ee]nterprise: +(.*)`)
 )
 
-type changelogGenerator struct {
-	repo           string
-	ghclient       *github.Client
-	excludePRLinks bool
+// changelogScraper is used to scrape changelog information from GitHub pull requests.
+type changelogScraper struct {
+	repo     string
+	ghclient ghClient
+	// markAllEnterprise indicates if all changelogs should be marked as enterprise
+	markAllEnterprise bool
 }
 
-// generateChangelog will pull a PRs from branch between two points in time and generate a changelog from them.
-func (c *changelogGenerator) generateChangelog(ctx context.Context, branch string, fromTime, toTime time.Time) (string, error) {
+// ghClient is a small interface for the GitHub client to allow for easier testing.
+type ghClient interface {
+	ListChangelogPullRequests(ctx context.Context, owner, repo string, opts *github.ListChangelogPullRequestsOpts) ([]github.ChangelogPR, error)
+}
+
+// scrapeForChangelogs will search for pull requests between two points in time and attempt to extract changelog information from them.
+// This only considers PRs that have been labeled with the "changelog" label. Other PRs will be ignored.
+// In the case of no changelog lines found, this will use the PR title as the changelog with a NOCL prefix.
+//
+// Examples of changelog lines this will match:
+//   - "changelog: this is a changelog"
+//   - "changelog-enterprise: this is an enterprise changelog"
+//
+// Multiple changelog lines can be specified in a single PR.
+func (c *changelogScraper) scrapeForChangelogs(ctx context.Context, branch string, fromTime, toTime time.Time) ([]changelogInfo, error) {
 	// Search github for changelog pull requests
 	prs, err := c.ghclient.ListChangelogPullRequests(
 		ctx,
@@ -79,56 +81,55 @@ func (c *changelogGenerator) generateChangelog(ctx context.Context, branch strin
 		},
 	)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return []changelogInfo{}, trace.Wrap(err)
 	}
 
-	return c.toChangelog(prs)
-}
-
-// toChangelog will take the output from the search and format it into a changelog.
-func (c *changelogGenerator) toChangelog(prs []github.ChangelogPR) (string, error) {
-	var clList []changelogInfo
+	changelogs := []changelogInfo{}
 	for _, pr := range prs {
-		clList = append(clList, newChangelogInfoFromPR(pr)...)
+		changelogs = append(changelogs, c.extractChangelogsFromPR(pr)...)
 	}
 
-	var buff bytes.Buffer
-	tmpl := clParsedTmpl
-	if c.excludePRLinks {
-		tmpl = clParsedTmplNoLink
-	}
-	if err := tmpl.Execute(&buff, clList); err != nil {
-		return "", trace.Wrap(err)
-	}
-
-	return buff.String(), nil
+	return changelogs, nil
 }
 
-// convertPRToChangelog will convert the list of PRs to a nicer format.
-func newChangelogInfoFromPR(pr github.ChangelogPR) []changelogInfo {
+// extractChangelogsFromPR will attempt to extract changelog information from a given PR.
+// This will look for changelog entries in the PR body and return a list of changelog information.
+func (c *changelogScraper) extractChangelogsFromPR(pr github.ChangelogPR) []changelogInfo {
 	var result []changelogInfo
 
 	info := changelogInfo{
-		Summary: "NOCL: " + pr.Title, // default summary
-		Number:  pr.Number,
-		URL:     pr.URL,
+		Summary:      "NOCL: " + pr.Title, // default summary
+		Number:       pr.Number,
+		URL:          pr.URL,
+		IsEnterprise: c.markAllEnterprise,
 	}
 
-	changelogs := findChangelogs(pr.Body)
-	if len(changelogs) == 0 {
-		return []changelogInfo{info}
-	}
-	for _, summary := range changelogs {
+	changelogLines := findChangelogLines(pr.Body, clPattern)
+	for _, summary := range changelogLines {
 		info.Summary = prettierSummary(summary)
 		result = append(result, info)
 	}
+
+	entChangelogLines := findChangelogLines(pr.Body, entCLPattern)
+	if len(entChangelogLines) > 0 {
+		for _, summary := range entChangelogLines {
+			info.Summary = prettierSummary(summary)
+			info.IsEnterprise = true
+			result = append(result, info)
+		}
+	}
+
+	if len(result) == 0 {
+		return []changelogInfo{info}
+	}
+
 	return result
 }
 
-// findChangelogs will parse a body of a PR to find it's changelogs.
-func findChangelogs(commentBody string) []string {
+// findChangelogLines will parse a body of a PR with a given pattern to find its changelogs.
+func findChangelogLines(commentBody string, pattern *regexp.Regexp) []string {
 	var result []string
-	matches := clPattern.FindAllStringSubmatch(commentBody, -1)
+	matches := pattern.FindAllStringSubmatch(commentBody, -1)
 	for _, m := range matches {
 		// If a match is found then we should get a non empty slice
 		// 0 index will be the whole match including "changelog: *"

--- a/tools/changelog/changelog_test.go
+++ b/tools/changelog/changelog_test.go
@@ -17,55 +17,62 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"os"
-	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gravitational/shared-workflows/libs/github"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func decodeTestData(t *testing.T, data []byte) []github.ChangelogPR {
-	prs := []github.ChangelogPR{}
-	dec := json.NewDecoder(bytes.NewReader(data))
-	require.NoError(t, dec.Decode(&prs))
-	return prs
+func TestChangelogScraper(t *testing.T) {
+	// Test the changelog scraper functionality
+	scraper := &changelogScraper{
+		repo: "test-repo",
+		ghclient: &fakeGitHubClient{
+			testFileName: "testdata/listed-prs.json",
+		},
+	}
+
+	data, err := scraper.scrapeForChangelogs(t.Context(), "master", time.Now(), time.Now())
+	assert.NoError(t, err)
+	assert.NotEmpty(t, data)
+	assert.Len(t, data, 23)
+
+	coreCLCount := 0
+	entCLCount := 0
+	for _, item := range data {
+		if !item.IsEnterprise {
+			coreCLCount++
+		} else {
+			entCLCount++
+		}
+	}
+	assert.Equal(t, 20, coreCLCount)
+	assert.Equal(t, 3, entCLCount)
 }
 
-func TestToChangelog(t *testing.T) {
-	testCases := []struct {
-		name           string
-		expectedFile   string
-		excludePRLinks bool
-	}{
-		{
-			name:           "include-links",
-			expectedFile:   "expected-cl.md",
-			excludePRLinks: false,
-		},
-		{
-			name:           "exclude-links",
-			expectedFile:   "expected-cl-no-links.md",
-			excludePRLinks: true,
-		},
+func TestFindChangelogLinesCoreAndEnterpriseMarkers(t *testing.T) {
+	body := `
+- changelog: core fix
+* changelog-enterprise: paid feature
+`
+
+	assert.Equal(t, []string{"core fix"}, findChangelogLines(body, clPattern))
+	assert.Equal(t, []string{"paid feature"}, findChangelogLines(body, entCLPattern))
+}
+
+func TestExtractChangelogsFromPREnterpriseOnly(t *testing.T) {
+	pr := github.ChangelogPR{
+		Title:  "Fallback title",
+		Number: 42,
+		URL:    "https://example.test/pull/42",
+		Body:   "changelog-enterprise: enterprise behavior",
 	}
 
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			prsText, err := os.ReadFile(filepath.Join("testdata", "listed-prs.json"))
-			require.NoError(t, err)
-			expectedCL, err := os.ReadFile(filepath.Join("testdata", tt.expectedFile))
-			require.NoError(t, err)
+	scraper := &changelogScraper{}
 
-			prs := decodeTestData(t, prsText)
-
-			gen := &changelogGenerator{excludePRLinks: tt.excludePRLinks}
-			got, err := gen.toChangelog(prs)
-			assert.NoError(t, err)
-			assert.Equal(t, string(expectedCL), got)
-		})
-	}
+	items := scraper.extractChangelogsFromPR(pr)
+	assert.Len(t, items, 1)
+	assert.Equal(t, "Enterprise behavior.", items[0].Summary)
+	assert.True(t, items[0].IsEnterprise)
 }

--- a/tools/changelog/fakegithubclient.go
+++ b/tools/changelog/fakegithubclient.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2024 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/gravitational/shared-workflows/libs/github"
+)
+
+// fakeGitHubClient is a fake implementation of the GitHub client for testing purposes.
+type fakeGitHubClient struct {
+	testFileName string
+}
+
+func (f *fakeGitHubClient) ListChangelogPullRequests(ctx context.Context, owner, repo string, opts *github.ListChangelogPullRequestsOpts) ([]github.ChangelogPR, error) {
+	testFile, err := os.Open(f.testFileName)
+	if err != nil {
+		return []github.ChangelogPR{}, err
+	}
+	defer testFile.Close()
+
+	decoder := json.NewDecoder(testFile)
+	var changelogPRs []github.ChangelogPR
+	if err := decoder.Decode(&changelogPRs); err != nil {
+		return []github.ChangelogPR{}, err
+	}
+
+	// For testing purposes, we can return a hardcoded response or an error
+	return changelogPRs, nil
+}

--- a/tools/changelog/main.go
+++ b/tools/changelog/main.go
@@ -44,13 +44,23 @@ var (
 		"The tag/version to generate the changelog from. It will be of the form vXX.Y.Z, e.g. v15.1.1",
 	).Envar("BASE_TAG").String()
 
+	privateRepoName = kingpin.Flag(
+		"private-repo-name",
+		"The name of the private repository.",
+	).Envar("PRIVATE_REPO_NAME").String()
+
+	monoRepoEnabled = kingpin.Flag(
+		"mono-repo-enabled",
+		"Whether the repository is a mono-repo.",
+	).Envar("MONO_REPO_ENABLED").Bool()
+
 	dir = kingpin.Arg("dir", "directory of the teleport repo.").Required().String()
 )
 
 func main() {
 	kingpin.Parse()
 
-	ossRepo, entRepo, err := initGit(*dir)
+	ossRepo, err := git.NewRepoFromDirectory(*dir)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -71,61 +81,81 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	timeLastEntRelease, timeLastEntMod, err := entTimestamps(entRepo, lastVersion)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	cl, err := github.NewClientFromGHAuth(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Bump the time of the last release (both OSS and Enterprise) by 1 second
-	// as we do not want to include the commit in the last release.
+	// This is to exclude the commit of the last release from the changelog.
 	timeLastRelease = timeLastRelease.Add(1 * time.Second)
-	timeLastEntRelease = timeLastEntRelease.Add(1 * time.Second)
-	timeLastEntMod = timeLastEntMod.Add(1 * time.Second)
+
+	// By default, we pull from the OSS repository
+	// However, we have situations where we need to pull from a private repository.
+	// In these cases, the PR links are not relevant to external users so we exclude them.
+	var repoName = "teleport"
+	var excludePRLinks = false
+	if *privateRepoName != "" {
+		repoName = *privateRepoName
+		excludePRLinks = true
+	}
 
 	// Generate changelogs
 	ctx := context.Background()
-	ossCLGen := &changelogGenerator{
+	coreRepoScraper := &changelogScraper{
 		ghclient: cl,
-		repo:     "teleport",
+		repo:     repoName,
 	}
-	entCLGen := &changelogGenerator{
-		ghclient:       cl,
-		repo:           "teleport.e",
-		excludePRLinks: true,
-	}
-	ossCL, err := ossCLGen.generateChangelog(ctx, branch, timeLastRelease, github.SearchTimeNow)
-	if err != nil {
-		log.Fatal(err)
-	}
-	entCL, err := entCLGen.generateChangelog(ctx, branch, timeLastEntRelease, timeLastEntMod)
+	changelogs, err := coreRepoScraper.scrapeForChangelogs(ctx, branch, timeLastRelease, github.SearchTimeNow)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println(ossCL)
-	if entCL != "" {
-		fmt.Println("Enterprise:")
-		fmt.Println(entCL)
+	if !*monoRepoEnabled { // If not a monorepo, we need to gather enterprise changelogs from the enterprise repository
+		enterpriseChangelogs, err := gatherEnterpriseChangelogs(ctx, cl, branch, lastVersion)
+		if err != nil {
+			log.Fatal(err)
+		}
+		changelogs = append(changelogs, enterpriseChangelogs...)
 	}
+
+	rendered, err := renderChangelog(renderOpts{
+		changelogs:         changelogs,
+		excludeCorePRLinks: excludePRLinks,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(rendered)
+
 }
 
-// initGit will initialize git repo for teleport OSS and Enterprise.
-func initGit(repoRootDir string) (oss, ent *git.Repo, err error) {
-	oss, err = git.NewRepoFromDirectory(repoRootDir)
+// gatherEnterpriseChangelogs gathers the changelogs from the enterprise-only repository.
+func gatherEnterpriseChangelogs(ctx context.Context, cl *github.Client, branch string, lastVersion string) ([]changelogInfo, error) {
+	// Initialize from the e subdir which contains the repository information for enterprise-only changes
+	enterpriseRepo, err := git.NewRepoFromDirectory(filepath.Join(*dir, "e"))
 	if err != nil {
-		return oss, ent, trace.Wrap(err)
+		return []changelogInfo{}, trace.Wrap(err)
 	}
 
-	ent, err = git.NewRepoFromDirectory(filepath.Join(repoRootDir, "e"))
+	timeLastEntRelease, timeLastEntMod, err := entTimestamps(enterpriseRepo, lastVersion)
 	if err != nil {
-		return oss, ent, trace.Wrap(err)
+		return []changelogInfo{}, trace.Wrap(err)
 	}
-	return
+	timeLastEntRelease = timeLastEntRelease.Add(1 * time.Second)
+	timeLastEntMod = timeLastEntMod.Add(1 * time.Second)
+
+	entCLGen := &changelogScraper{
+		ghclient:          cl,
+		repo:              "teleport.e",
+		markAllEnterprise: true,
+	}
+
+	entCL, err := entCLGen.scrapeForChangelogs(ctx, branch, timeLastEntRelease, timeLastEntMod)
+	if err != nil {
+		return []changelogInfo{}, trace.Wrap(err)
+	}
+	return entCL, nil
 }
 
 // getBranch will return branch if parsed otherwise will attempt to find it

--- a/tools/changelog/main.go
+++ b/tools/changelog/main.go
@@ -51,7 +51,7 @@ var (
 
 	monoRepoEnabled = kingpin.Flag(
 		"mono-repo-enabled",
-		"Whether the repository is a mono-repo.",
+		"Whether the repository is a mono-repo. When true, only generates changelogs from the core repository. When false, also includes changelogs from the enterprise repository.",
 	).Envar("MONO_REPO_ENABLED").Bool()
 
 	dir = kingpin.Arg("dir", "directory of the teleport repo.").Required().String()

--- a/tools/changelog/renderer.go
+++ b/tools/changelog/renderer.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	clTemplate = `
+{{- range .Core -}}
+* {{.Summary}} [#{{.Number}}]({{.URL}})
+{{ end -}}
+{{ if .Enterprise }}
+Enterprise
+{{ range .Enterprise -}}
+* {{.Summary}}
+{{ end -}}
+{{- end -}}
+`
+	clTemplateNoLink = `
+{{- range .Core -}}
+* {{.Summary}}
+{{ end -}}
+{{ if .Enterprise }}
+Enterprise
+{{ range .Enterprise -}}
+* {{.Summary}}
+{{ end -}}
+{{- end -}}
+`
+)
+
+var (
+	clParsedTmpl       = template.Must(template.New("cl").Parse(clTemplate))
+	clParsedTmplNoLink = template.Must(template.New("cl").Parse(clTemplateNoLink))
+)
+
+type renderOpts struct {
+	changelogs         []changelogInfo
+	excludeCorePRLinks bool
+}
+
+type renderData struct {
+	Core       []changelogInfo
+	Enterprise []changelogInfo
+}
+
+func renderChangelog(opts renderOpts) (string, error) {
+	var buff bytes.Buffer
+
+	coreChangelogs := []changelogInfo{}
+	enterpriseChangelogs := []changelogInfo{}
+
+	for _, cl := range opts.changelogs {
+		if cl.IsEnterprise {
+			enterpriseChangelogs = append(enterpriseChangelogs, cl)
+		} else {
+			coreChangelogs = append(coreChangelogs, cl)
+		}
+	}
+
+	if len(coreChangelogs) == 0 && len(enterpriseChangelogs) == 0 {
+		return "", nil
+	}
+
+	tmpl := clParsedTmpl
+	if opts.excludeCorePRLinks {
+		tmpl = clParsedTmplNoLink
+	}
+
+	if err := tmpl.Execute(&buff, renderData{Core: coreChangelogs, Enterprise: enterpriseChangelogs}); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return buff.String(), nil
+}

--- a/tools/changelog/renderer_test.go
+++ b/tools/changelog/renderer_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Overall this is mainly for testing that the templating is working as expected.
+// This allows for faster iteration of the template itself and doesn't have much logic to test.
+func TestRenderChangelog(t *testing.T) {
+	testCases := []struct {
+		name           string
+		expectedFile   string
+		excludePRLinks bool
+	}{
+		{
+			name:           "include-links",
+			expectedFile:   "expected-cl.md",
+			excludePRLinks: false,
+		},
+		{
+			name:           "exclude-links",
+			expectedFile:   "expected-cl-no-links.md",
+			excludePRLinks: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			scraper := &changelogScraper{
+				repo: "test-repo",
+				ghclient: &fakeGitHubClient{
+					testFileName: "testdata/listed-prs.json",
+				},
+			}
+			changelogs, err := scraper.scrapeForChangelogs(t.Context(), "master", time.Now(), time.Now())
+			require.NoError(t, err)
+			require.NotEmpty(t, changelogs)
+
+			got, err := renderChangelog(renderOpts{
+				changelogs:         changelogs,
+				excludeCorePRLinks: tt.excludePRLinks,
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, got)
+
+			expected, err := os.ReadFile("testdata/" + tt.expectedFile)
+			require.NoError(t, err)
+			assert.Equal(t, string(expected), got)
+		})
+	}
+}

--- a/tools/changelog/testdata/expected-cl-no-links.md
+++ b/tools/changelog/testdata/expected-cl-no-links.md
@@ -17,3 +17,9 @@
 * Improved log rotation logic in Teleport Connect; now the non-numbered files always contain recent logs.
 * Adds `tctl desktop bootstrap` for bootstrapping AD environments to work with Desktop Access.
 * Adds a changelog for testing.
+* Adds a normal changelog between two enterprise for testing.
+
+Enterprise
+* Adds an enterprise changelog for testing.
+* Adds a second enterprise changelog for testing.
+* Adds a third enterprise changelog for testing.

--- a/tools/changelog/testdata/expected-cl.md
+++ b/tools/changelog/testdata/expected-cl.md
@@ -17,3 +17,9 @@
 * Improved log rotation logic in Teleport Connect; now the non-numbered files always contain recent logs. [#43161](https://github.com/gravitational/teleport/pull/43161)
 * Adds `tctl desktop bootstrap` for bootstrapping AD environments to work with Desktop Access. [#43150](https://github.com/gravitational/teleport/pull/43150)
 * Adds a changelog for testing. [#43150](https://github.com/gravitational/teleport/pull/43150)
+* Adds a normal changelog between two enterprise for testing. [#43150](https://github.com/gravitational/teleport/pull/43150)
+
+Enterprise
+* Adds an enterprise changelog for testing.
+* Adds a second enterprise changelog for testing.
+* Adds a third enterprise changelog for testing.

--- a/tools/changelog/testdata/listed-prs.json
+++ b/tools/changelog/testdata/listed-prs.json
@@ -106,5 +106,17 @@
         "number": 43150,
         "title": "[v16] Adds `tctl desktop bootstrap`, updates docs.",
         "url": "https://github.com/gravitational/teleport/pull/43150"
+    },
+    {
+        "body": "backport  #42161 to branch/v16\r\nchangelog-enterprise: Adds an enterprise changelog for testing.\r\n",
+        "number": 43150,
+        "title": "[v16] This only has enterprise changelogs.",
+        "url": "https://github.com/gravitational/teleport/pull/43150"
+    },
+    {
+        "body": "backport  #42161 to branch/v16\r\nchangelog-enterprise: Adds a second enterprise changelog for testing.\r\nchangelog: Adds a normal changelog between two enterprise for testing.\r\nchangelog-enterprise: Adds a third enterprise changelog for testing.\r\n",
+        "number": 43150,
+        "title": "[v16] This only has enterprise changelogs.",
+        "url": "https://github.com/gravitational/teleport/pull/43150"
     }
 ]


### PR DESCRIPTION
## Overview

This is a small refactor to the changelog tool to support the new monorepo setup we have. The main features introduced are:
- Added the ability to search through private repositories for changelog information
- Now supports enterprise specific changelogs through a new `changelog-enterprise` marker
  - ie `changelog-enterprise: Introducing a new enterprise only feature or bugfix`
  - This allows differentiating between enterprise only changes & core changes in the monorepo

## Alternatives considered

- Labels for differentiating enterprise only changes from core changes
  - It's likely that a new use-case for PRs that contain both types of changes will occur in the new monorepo. A label would necessitate that PRs must be split based on whether they are an enterprise-only change or core change which is confusing and limiting.