### PR TITLE
env-kvstore: install binaries in temp directory

### DIFF
--- a/tools/env-kvstore/Makefile
+++ b/tools/env-kvstore/Makefile
@@ -1,6 +1,5 @@
 TOOL_NAME = env-kvstore
 PACKAGE_PATH = ./cmd
-VERSION = v1.0.0
-
+VERSION = v1.0.1
 
 include ../repo-release-tooling/tooling.mk

--- a/tools/env-kvstore/action.yaml
+++ b/tools/env-kvstore/action.yaml
@@ -41,6 +41,7 @@ runs:
       with:
         tool-name: env-kvstore
         tag-prefix: tools/env-kvstore/
+        install-dir: ${{ runner.temp }}/env-kvstore
     - name: Retrieve variables and secrets from KVStore
       id: retrieve_from_kvstore
       shell: bash


### PR DESCRIPTION
Currently the default behaviour of `install-gh-release` places action binaries in `/opt/bin` which is not necessarily writeable when `env-kvstore` is being using inside a container.

This PR installs the action in a writeable temp folder in the runner's working directory instead.