### PR TITLE
Adding fix-license makefile target

### DIFF
--- a/tools/repo-release-tooling/tooling.mk
+++ b/tools/repo-release-tooling/tooling.mk
@@ -47,8 +47,13 @@ clean:
 
 .PHONY: print-tool-name print-version lint test generate binary tarball container-image clean
 
+ADDLICENSE_ARGS = -l apache -c 'Gravitational, Inc.' \
+	-ignore 'workflows/**'
+
 fix-license:
-	go run github.com/google/addlicense@v1.0.0 -l apache \
-		-c 'Gravitational, Inc.' \
-		-ignore 'workflows/**' \
-		.
+	go run github.com/google/addlicense@v1.0.0 $(ADDLICENSE_ARGS) .
+
+lint-license:
+	@echo "Checking license headers..."
+	@echo "If you see any output below, it means that some files are missing license headers."
+	go run github.com/google/addlicense@v1.0.0 -check $(ADDLICENSE_ARGS) .

--- a/tools/repo-release-tooling/tooling.mk
+++ b/tools/repo-release-tooling/tooling.mk
@@ -46,3 +46,9 @@ clean:
 	@docker image rm -f "$(TOOL_NAME):$(CONTAINER_VERSION)" 2> /dev/null > /dev/null
 
 .PHONY: print-tool-name print-version lint test generate binary tarball container-image clean
+
+fix-license:
+	go run github.com/google/addlicense@v1.0.0 -l apache \
+		-c 'Gravitational, Inc.' \
+		-ignore 'workflows/**' \
+		.


### PR DESCRIPTION
Similar functionality to our OSS repo, this adds a fix-license (and lint-license) makefile target to automatically manage the license headers in this repository.