### PR TITLE
Correcting module path for retry tool

### DIFF
--- a/tools/retry/go.mod
+++ b/tools/retry/go.mod
@@ -1,3 +1,3 @@
-module retry
+module github.com/gravitational/shared-workflows/tools/retry
 
 go 1.24.10


### PR DESCRIPTION
Changing the module path for the retry tool to match the URL where the `go` tool can find the code. This follows the [normal recommendation](https://go.dev/doc/modules/gomod-ref#module-notes).

This will allow the `go` tool to correctly resolve the module. Currently attempting to use the expected module name `github.com/gravitational/shared-workflows/tools/retry` in `go` commands results in the following error

```
go: github.com/gravitational/shared-workflows/tools/retry@v0.0.1 requires github.com/gravitational/shared-workflows/tools/retry@v0.0.1: parsing go.mod:
        module declares its path as: retry
                but was required as: github.com/gravitational/shared-workflows/tools/retry
```

After this change, we should be able to use `go run <module>`, `go install <module>`, and `go get <module>` successfully.