### PR TITLE
bot: reviewers flag is unused on many workflows

### DIFF
--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -43,6 +43,8 @@ const (
 	// PostReleaseBot is the name of the bot user that creates post-release PRs
 	// such as AMI and docs version updates.
 	PostReleaseBot = "teleport-post-release-automation[bot]"
+	// EmptyReviewers is a sentinel value used when the CLI flag is absent/empty
+	EmptyReviewers = "{}"
 )
 
 var (
@@ -170,7 +172,11 @@ type Assignments struct {
 }
 
 // FromString parses JSON formatted configuration and returns assignments.
-func FromString(e *env.Environment, reviewers string) (*Assignments, error) {
+func FromString(reviewers string) (*Assignments, error) {
+	if reviewers == EmptyReviewers {
+		log.Printf("Generating assignments/reviewers from empty configuration.")
+		return New(emptyConfig())
+	}
 	var c Config
 	if err := json.Unmarshal([]byte(reviewers), &c); err != nil {
 		return nil, trace.Wrap(err)
@@ -194,6 +200,22 @@ func New(c *Config) (*Assignments, error) {
 	return &Assignments{
 		c: c,
 	}, nil
+}
+
+// emptyConfig returns a struct initialized with empty maps and slices that can pass
+// CheckAndSetDefaults()
+func emptyConfig() *Config {
+	var c Config = Config{
+		CodeReviewersOmit: map[string]bool{},
+		RepoReviewers:     map[string]map[string]Reviewer{},
+		CoreReviewers:     map[string]Reviewer{},
+		CloudReviewers:    map[string]Reviewer{},
+		DocsReviewers:     map[string]Reviewer{},
+		DocsReviewersOmit: map[string]bool{},
+		ReleaseReviewers:  []string{},
+		Admins:            []string{},
+	}
+	return &c
 }
 
 // IsInternal checks whether the author of a PR is explicitly

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -1202,8 +1202,7 @@ func TestCheckInternal(t *testing.T) {
 
 // TestFromString tests if configuration is correctly read in from a string.
 func TestFromString(t *testing.T) {
-	e := &env.Environment{Repository: env.TeleportRepo}
-	r, err := FromString(e, reviewers)
+	r, err := FromString(reviewers)
 	require.NoError(t, err)
 
 	require.EqualValues(t, r.c.CoreReviewers, map[string]Reviewer{
@@ -1359,6 +1358,17 @@ func TestSingleApproverAuthors(t *testing.T) {
 		})
 		require.Equal(t, -1, i, "%q is not allowed to be a single approver author in the %q repository (only bots)", name(authors, i), repo)
 	}
+}
+
+func TestEmptyConfigCheckAndSetDefaults(t *testing.T) {
+	c := emptyConfig()
+	require.NoError(t, c.CheckAndSetDefaults())
+}
+
+func TestFromStringEmptyReviewers(t *testing.T) {
+	r, err := FromString(EmptyReviewers)
+	require.NoError(t, err)
+	require.NotNil(t, r)
 }
 
 const reviewers = `

--- a/bot/main.go
+++ b/bot/main.go
@@ -235,6 +235,7 @@ func createBotLocal(ctx context.Context, flags flags) (*bot.Bot, error) {
 // reviewers flag value: assign, bloat, check, exclude-flakes or rfd
 func workflowNeedsReviewers(workflow string) bool {
 	return workflow == "assign" ||
+		workflow == "backport" ||
 		workflow == "bloat" ||
 		workflow == "check" ||
 		workflow == "exclude-flakes" ||

--- a/bot/main.go
+++ b/bot/main.go
@@ -148,7 +148,7 @@ func parseFlags() (flags, error) {
 		return flags{}, trace.BadParameter("token missing")
 	}
 	if !workflowNeedsReviewers(*workflow) && *reviewers == "" {
-		*reviewers = "{}"
+		*reviewers = review.EmptyReviewers
 	}
 	if *reviewers == "" && !*local {
 		return flags{}, trace.BadParameter("reviewers required for assign and check")
@@ -199,7 +199,7 @@ func createBot(ctx context.Context, flags flags) (*bot.Bot, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	reviewer, err := review.FromString(environment, flags.reviewers)
+	reviewer, err := review.FromString(flags.reviewers)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -234,10 +234,9 @@ func createBotLocal(ctx context.Context, flags flags) (*bot.Bot, error) {
 // workflowRequiresReviewers checks whether the workflow is one that uses the
 // reviewers flag value: assign, bloat, check, exclude-flakes or rfd
 func workflowNeedsReviewers(workflow string) bool {
-	return workflow == "assign" ||
-		workflow == "backport" ||
-		workflow == "bloat" ||
-		workflow == "check" ||
-		workflow == "exclude-flakes" ||
-		workflow == "rfd"
+	switch workflow {
+	case "assign", "backport", "bloat", "check", "exclude-flakes", "rfd":
+		return true
+	}
+	return false
 }

--- a/bot/main.go
+++ b/bot/main.go
@@ -147,6 +147,9 @@ func parseFlags() (flags, error) {
 	if *token == "" {
 		return flags{}, trace.BadParameter("token missing")
 	}
+	if !workflowNeedsReviewers(*workflow) && *reviewers == "" {
+		*reviewers = "{}"
+	}
 	if *reviewers == "" && !*local {
 		return flags{}, trace.BadParameter("reviewers required for assign and check")
 	}
@@ -226,4 +229,14 @@ func createBotLocal(ctx context.Context, flags flags) (*bot.Bot, error) {
 			Number:       flags.prNumber,
 		},
 	})
+}
+
+// workflowRequiresReviewers checks whether the workflow is one that uses the
+// reviewers flag value: assign, bloat, check, exclude-flakes or rfd
+func workflowNeedsReviewers(workflow string) bool {
+	return workflow == "assign" ||
+		workflow == "bloat" ||
+		workflow == "check" ||
+		workflow == "exclude-flakes" ||
+		workflow == "rfd"
 }

--- a/bot/main_test.go
+++ b/bot/main_test.go
@@ -65,6 +65,16 @@ func TestParseFlagsWorkflowNeedsReviewers(t *testing.T) {
 			wantErr:  true,
 		},
 		{
+			desc:     "backport without reviewers",
+			workflow: "backport",
+			wantErr:  true,
+		},
+		{
+			desc:     "bloat without reviewers",
+			workflow: "bloat",
+			wantErr:  true,
+		},
+		{
 			desc:     "check without reviewers",
 			workflow: "check",
 			wantErr:  true,
@@ -79,15 +89,22 @@ func TestParseFlagsWorkflowNeedsReviewers(t *testing.T) {
 			workflow: "rfd",
 			wantErr:  true,
 		},
-		{
-			desc:     "bloat without reviewers",
-			workflow: "bloat",
-			wantErr:  true,
-		},
 		// workflows that need reviewers – with reviewers → success
 		{
 			desc:          "assign with reviewers",
 			workflow:      "assign",
+			reviewers:     dummyReviewers,
+			wantReviewers: dummyReviewers,
+		},
+		{
+			desc:          "backport with reviewers",
+			workflow:      "backport",
+			reviewers:     dummyReviewers,
+			wantReviewers: dummyReviewers,
+		},
+		{
+			desc:          "bloat with reviewers",
+			workflow:      "bloat",
 			reviewers:     dummyReviewers,
 			wantReviewers: dummyReviewers,
 		},
@@ -106,12 +123,6 @@ func TestParseFlagsWorkflowNeedsReviewers(t *testing.T) {
 		{
 			desc:          "rfd with reviewers",
 			workflow:      "rfd",
-			reviewers:     dummyReviewers,
-			wantReviewers: dummyReviewers,
-		},
-		{
-			desc:          "bloat with reviewers",
-			workflow:      "bloat",
 			reviewers:     dummyReviewers,
 			wantReviewers: dummyReviewers,
 		},
@@ -137,11 +148,6 @@ func TestParseFlagsWorkflowNeedsReviewers(t *testing.T) {
 		{
 			desc:          "label without reviewers",
 			workflow:      "label",
-			wantReviewers: "{}",
-		},
-		{
-			desc:          "backport without reviewers",
-			workflow:      "backport",
 			wantReviewers: "{}",
 		},
 		{

--- a/bot/main_test.go
+++ b/bot/main_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseFlagsReviewers(t *testing.T) {
+func TestParseFlagsReviewersBase64(t *testing.T) {
 	dummyArgs := []string{
 		os.Args[0],
 		"-workflow",
@@ -39,4 +39,161 @@ func TestParseFlagsReviewers(t *testing.T) {
 
 	// Basic checks
 	assert.Equal(t, testValueJSON, b64Flags.reviewers)
+}
+
+func TestParseFlagsWorkflowNeedsReviewers(t *testing.T) {
+	const dummyToken = "test-token"
+	const dummyReviewers = `{"core":{}}`
+
+	tests := []struct {
+		desc          string
+		workflow      string
+		reviewers     string
+		local         bool
+		wantErr       bool
+		wantReviewers string
+	}{
+		// missing workflow
+		{
+			desc:    "missing workflow",
+			wantErr: true,
+		},
+		// workflows that need reviewers – without reviewers → error
+		{
+			desc:     "assign without reviewers",
+			workflow: "assign",
+			wantErr:  true,
+		},
+		{
+			desc:     "check without reviewers",
+			workflow: "check",
+			wantErr:  true,
+		},
+		{
+			desc:     "exclude-flakes without reviewers",
+			workflow: "exclude-flakes",
+			wantErr:  true,
+		},
+		{
+			desc:     "rfd without reviewers",
+			workflow: "rfd",
+			wantErr:  true,
+		},
+		{
+			desc:     "bloat without reviewers",
+			workflow: "bloat",
+			wantErr:  true,
+		},
+		// workflows that need reviewers – with reviewers → success
+		{
+			desc:          "assign with reviewers",
+			workflow:      "assign",
+			reviewers:     dummyReviewers,
+			wantReviewers: dummyReviewers,
+		},
+		{
+			desc:          "check with reviewers",
+			workflow:      "check",
+			reviewers:     dummyReviewers,
+			wantReviewers: dummyReviewers,
+		},
+		{
+			desc:          "exclude-flakes with reviewers",
+			workflow:      "exclude-flakes",
+			reviewers:     dummyReviewers,
+			wantReviewers: dummyReviewers,
+		},
+		{
+			desc:          "rfd with reviewers",
+			workflow:      "rfd",
+			reviewers:     dummyReviewers,
+			wantReviewers: dummyReviewers,
+		},
+		{
+			desc:          "bloat with reviewers",
+			workflow:      "bloat",
+			reviewers:     dummyReviewers,
+			wantReviewers: dummyReviewers,
+		},
+		// local mode bypasses the reviewers requirement
+		{
+			desc:          "assign local no reviewers",
+			workflow:      "assign",
+			local:         true,
+			wantReviewers: "",
+		},
+		{
+			desc:          "check local no reviewers",
+			workflow:      "check",
+			local:         true,
+			wantReviewers: "",
+		},
+		// workflows that do NOT need reviewers – omitting -reviewers → defaults to "{}"
+		{
+			desc:          "dismiss without reviewers",
+			workflow:      "dismiss",
+			wantReviewers: "{}",
+		},
+		{
+			desc:          "label without reviewers",
+			workflow:      "label",
+			wantReviewers: "{}",
+		},
+		{
+			desc:          "backport without reviewers",
+			workflow:      "backport",
+			wantReviewers: "{}",
+		},
+		{
+			desc:          "verify without reviewers",
+			workflow:      "verify",
+			wantReviewers: "{}",
+		},
+		{
+			desc:          "binary-sizes without reviewers",
+			workflow:      "binary-sizes",
+			wantReviewers: "{}",
+		},
+		{
+			desc:          "changelog without reviewers",
+			workflow:      "changelog",
+			wantReviewers: "{}",
+		},
+		{
+			desc:          "docpaths without reviewers",
+			workflow:      "docpaths",
+			wantReviewers: "{}",
+		},
+		{
+			desc:          "manual-test-plan without reviewers",
+			workflow:      "manual-test-plan",
+			wantReviewers: "{}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+			args := []string{os.Args[0], "-token", dummyToken}
+			if tt.workflow != "" {
+				args = append(args, "-workflow", tt.workflow)
+			}
+			if tt.reviewers != "" {
+				args = append(args, "-reviewers", tt.reviewers)
+			}
+			if tt.local {
+				args = append(args, "-local")
+			}
+			os.Args = args
+
+			got, err := parseFlags()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantReviewers, got.reviewers)
+		})
+	}
 }


### PR DESCRIPTION
The `bot` GHA helper only uses the reviewers JSON on 6 of the workflow types.

This PR allows the remaining workflows to start without providing a value for the `reviewers` CLI flag.

To omit a value for workflows where the dependency is "optional" (table below) the flag must be explicitly set to "{}" when running the tool.

Workflow | Dependency |
|---|---|
| `assign` | Hard — `Review.Get()` |
| `check` | Hard — `Review.CheckInternal/External()` |
| `backport` | Optional — `isInternal()` fast path, skip GH API |
| `rfd` | Optional — `GetAdminCheckers()` for `/excluderfd` |
| `exclude-flakes` | Optional — `GetAdminCheckers()` for `/excludeflake` |
| `bloat` | Optional — `GetAdminCheckers()` for `/excludebloat` |
