### PR TITLE
Bumping retry to v0.0.2

### DIFF
--- a/tools/retry/Makefile
+++ b/tools/retry/Makefile
@@ -1,4 +1,4 @@
 TOOL_NAME = retry
-VERSION = v0.0.1
+VERSION = v0.0.2
 
 include ../repo-release-tooling/tooling.mk


### PR DESCRIPTION
This should pick up the latest change to the module path and allow us to pin to that version.