### PR TITLE
Add exclusion support in preferred reviewers config

### DIFF
--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -341,8 +341,8 @@ func (r *Assignments) getPreferredReviewers(teamReviewers map[string]Reviewer, s
 	// To avoid assigning too many reviewers iterate over paths that we have
 	// preferred reviewers for and see if any of them are among the changeset.
 	coveredPaths := make(map[string]struct{})
-	pathToPreferredReviewers, reviewersToExcludedPath := r.getPreferredReviewersMap(teamReviewers, set)
-	for path, reviewers := range pathToPreferredReviewers {
+	index := r.indexPreferredReviewersMap(teamReviewers, set)
+	for path, reviewers := range index.pathToReviewers {
 		if _, ok := coveredPaths[path]; ok {
 			continue
 		}
@@ -352,7 +352,7 @@ func (r *Assignments) getPreferredReviewers(teamReviewers map[string]Reviewer, s
 				// we need to check if the reviewer has a rule that excludes the file.
 				potentialReviewers := make([]string, 0, len(reviewers))
 				for _, reviewer := range reviewers {
-					if !reviewerExcludesPath(reviewersToExcludedPath[reviewer], file.Name) {
+					if !index.reviewerExcludesPath(reviewer, file.Name) {
 						potentialReviewers = append(potentialReviewers, reviewer)
 					}
 				}
@@ -384,8 +384,8 @@ func (r *Assignments) getAllPreferredReviewers(reviewers map[string]Reviewer, se
 	// to the set of preferred reviewers. Look up each reviewer in a map to
 	// avoid duplication.
 	assigned := make(map[string]struct{})
-	pathToPreferredReviewers, reviewersToExcludedPath := r.getPreferredReviewersMap(reviewers, set)
-	for path, reviewers := range pathToPreferredReviewers {
+	index := r.indexPreferredReviewersMap(reviewers, set)
+	for path, reviewers := range index.pathToReviewers {
 		for _, file := range files {
 			if !strings.HasPrefix(file.Name, path) {
 				continue
@@ -395,7 +395,7 @@ func (r *Assignments) getAllPreferredReviewers(reviewers map[string]Reviewer, se
 					continue
 				}
 
-				if !reviewerExcludesPath(reviewersToExcludedPath[rev], file.Name) {
+				if !index.reviewerExcludesPath(rev, file.Name) {
 					assigned[rev] = struct{}{}
 					preferredReviewers = append(preferredReviewers, rev)
 				}
@@ -405,9 +405,13 @@ func (r *Assignments) getAllPreferredReviewers(reviewers map[string]Reviewer, se
 	return preferredReviewers
 }
 
-// reviewerExcludesPath returns true if the reviewer has a rule that excludes the file.
-func reviewerExcludesPath(excludedPaths []string, path string) bool {
-	for _, excludedPath := range excludedPaths {
+type preferredReviewersIndex struct {
+	pathToReviewers         map[string][]string
+	reviewersToExcludedPath map[string][]string
+}
+
+func (i preferredReviewersIndex) reviewerExcludesPath(reviewer, path string) bool {
+	for _, excludedPath := range i.reviewersToExcludedPath[reviewer] {
 		if strings.HasPrefix(path, excludedPath) {
 			return true
 		}
@@ -415,12 +419,12 @@ func reviewerExcludesPath(excludedPaths []string, path string) bool {
 	return false
 }
 
-// getPreferredReviewersMap builds a map of preferred reviewers for file paths, and a map of excluded file paths for reviewers.
-func (r *Assignments) getPreferredReviewersMap(reviewers map[string]Reviewer, set []string) (map[string][]string, map[string][]string) {
-	// map[path][]reviewers
-	included := make(map[string][]string)
-	// map[reviewer][]excluded-paths
-	excluded := make(map[string][]string)
+// indexPreferredReviewersMap builds an index of preferred reviewers for file paths, and of excluded file paths for reviewers.
+func (r *Assignments) indexPreferredReviewersMap(reviewers map[string]Reviewer, set []string) preferredReviewersIndex {
+	index := preferredReviewersIndex{
+		pathToReviewers:         make(map[string][]string),
+		reviewersToExcludedPath: make(map[string][]string),
+	}
 	for _, name := range set {
 		if reviewer, ok := reviewers[name]; ok {
 			for _, path := range reviewer.PreferredReviewerFor {
@@ -428,14 +432,14 @@ func (r *Assignments) getPreferredReviewersMap(reviewers map[string]Reviewer, se
 					continue
 				}
 				if path[0] == '!' {
-					excluded[name] = append(excluded[name], path[1:])
+					index.reviewersToExcludedPath[name] = append(index.reviewersToExcludedPath[name], path[1:])
 				} else {
-					included[path] = append(included[path], name)
+					index.pathToReviewers[path] = append(index.pathToReviewers[path], name)
 				}
 			}
 		}
 	}
-	return included, excluded
+	return index
 }
 
 // getAdminReviewers returns the list of admin reviewers. Respects code

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -341,13 +341,34 @@ func (r *Assignments) getPreferredReviewers(teamReviewers map[string]Reviewer, s
 	// To avoid assigning too many reviewers iterate over paths that we have
 	// preferred reviewers for and see if any of them are among the changeset.
 	coveredPaths := make(map[string]struct{})
-	for path, reviewers := range r.getPreferredReviewersMap(teamReviewers, set) {
+	pathToPreferredReviewers, reviewersToExcludedPath := r.getPreferredReviewersMap(teamReviewers, set)
+	for path, reviewers := range pathToPreferredReviewers {
 		if _, ok := coveredPaths[path]; ok {
 			continue
 		}
 		for _, file := range files {
 			if strings.HasPrefix(file.Name, path) {
-				reviewer := reviewers[r.c.Rand.Intn(len(reviewers))]
+				// Before marking that the preferred path is covered,
+				// we need to check if the reviewer has a rule that excludes the file.
+				potentialReviewers := make([]string, 0, len(reviewers))
+				for _, reviewer := range reviewers {
+					excluded := false
+					for _, excludedPath := range reviewersToExcludedPath[reviewer] {
+						if strings.HasPrefix(file.Name, excludedPath) {
+							excluded = true
+							break
+						}
+					}
+					if !excluded {
+						potentialReviewers = append(potentialReviewers, reviewer)
+					}
+				}
+
+				if len(potentialReviewers) == 0 {
+					continue
+				}
+
+				reviewer := potentialReviewers[r.c.Rand.Intn(len(potentialReviewers))]
 				log.Printf("Picking %v as preferred reviewer for %v which matches %v.", reviewer, file.Name, path)
 				preferredReviewers = append(preferredReviewers, reviewer)
 				for _, path := range teamReviewers[reviewer].PreferredReviewerFor {
@@ -361,8 +382,8 @@ func (r *Assignments) getPreferredReviewers(teamReviewers map[string]Reviewer, s
 }
 
 // getAllPreferredReviewers returns a list of reviewers that would be
-// preferrable to review the provided changeset. Includes all preferred
-// reviewers for each file path in the changeset.
+// preferrable to review the provided changeset. Includes 1 preferred
+// reviewer for each file path in the changeset.
 func (r *Assignments) getAllPreferredReviewers(reviewers map[string]Reviewer, set []string, files []github.PullRequestFile) (preferredReviewers []string) {
 	// Check each key in the preferred reviewer map, which is a file path
 	// that reviewers are assigned to. For any file names in the changeset
@@ -370,7 +391,8 @@ func (r *Assignments) getAllPreferredReviewers(reviewers map[string]Reviewer, se
 	// to the set of preferred reviewers. Look up each reviewer in a map to
 	// avoid duplication.
 	assigned := make(map[string]struct{})
-	for path, reviewers := range r.getPreferredReviewersMap(reviewers, set) {
+	pathToPreferredReviewers, reviewersToExcludedPath := r.getPreferredReviewersMap(reviewers, set)
+	for path, reviewers := range pathToPreferredReviewers {
 		for _, file := range files {
 			if !strings.HasPrefix(file.Name, path) {
 				continue
@@ -379,25 +401,46 @@ func (r *Assignments) getAllPreferredReviewers(reviewers map[string]Reviewer, se
 				if _, ok := assigned[rev]; ok {
 					continue
 				}
-				assigned[rev] = struct{}{}
-				preferredReviewers = append(preferredReviewers, rev)
+
+				excluded := false
+				for _, excludedPath := range reviewersToExcludedPath[rev] {
+					if strings.HasPrefix(file.Name, excludedPath) {
+						excluded = true
+						break
+					}
+				}
+
+				if !excluded {
+					assigned[rev] = struct{}{}
+					preferredReviewers = append(preferredReviewers, rev)
+				}
 			}
 		}
 	}
 	return preferredReviewers
 }
 
-// getPreferredReviewersMap builds a map of preferred reviewers for file paths.
-func (r *Assignments) getPreferredReviewersMap(reviewers map[string]Reviewer, set []string) map[string][]string {
-	m := make(map[string][]string)
+// getPreferredReviewersMap builds a map of preferred reviewers for file paths, and a map of excluded file paths for reviewers.
+func (r *Assignments) getPreferredReviewersMap(reviewers map[string]Reviewer, set []string) (map[string][]string, map[string][]string) {
+	// map[path][]reviewers
+	included := make(map[string][]string)
+	// map[reviewer][]excluded-paths
+	excluded := make(map[string][]string)
 	for _, name := range set {
 		if reviewer, ok := reviewers[name]; ok {
 			for _, path := range reviewer.PreferredReviewerFor {
-				m[path] = append(m[path], name)
+				if len(path) == 0 {
+					continue
+				}
+				if path[0] == '!' {
+					excluded[name] = append(excluded[name], path[1:])
+				} else {
+					included[path] = append(included[path], name)
+				}
 			}
 		}
 	}
-	return m
+	return included, excluded
 }
 
 // getAdminReviewers returns the list of admin reviewers. Respects code

--- a/bot/internal/review/review.go
+++ b/bot/internal/review/review.go
@@ -352,14 +352,7 @@ func (r *Assignments) getPreferredReviewers(teamReviewers map[string]Reviewer, s
 				// we need to check if the reviewer has a rule that excludes the file.
 				potentialReviewers := make([]string, 0, len(reviewers))
 				for _, reviewer := range reviewers {
-					excluded := false
-					for _, excludedPath := range reviewersToExcludedPath[reviewer] {
-						if strings.HasPrefix(file.Name, excludedPath) {
-							excluded = true
-							break
-						}
-					}
-					if !excluded {
+					if !reviewerExcludesPath(reviewersToExcludedPath[reviewer], file.Name) {
 						potentialReviewers = append(potentialReviewers, reviewer)
 					}
 				}
@@ -402,15 +395,7 @@ func (r *Assignments) getAllPreferredReviewers(reviewers map[string]Reviewer, se
 					continue
 				}
 
-				excluded := false
-				for _, excludedPath := range reviewersToExcludedPath[rev] {
-					if strings.HasPrefix(file.Name, excludedPath) {
-						excluded = true
-						break
-					}
-				}
-
-				if !excluded {
+				if !reviewerExcludesPath(reviewersToExcludedPath[rev], file.Name) {
 					assigned[rev] = struct{}{}
 					preferredReviewers = append(preferredReviewers, rev)
 				}
@@ -418,6 +403,16 @@ func (r *Assignments) getAllPreferredReviewers(reviewers map[string]Reviewer, se
 		}
 	}
 	return preferredReviewers
+}
+
+// reviewerExcludesPath returns true if the reviewer has a rule that excludes the file.
+func reviewerExcludesPath(excludedPaths []string, path string) bool {
+	for _, excludedPath := range excludedPaths {
+		if strings.HasPrefix(path, excludedPath) {
+			return true
+		}
+	}
+	return false
 }
 
 // getPreferredReviewersMap builds a map of preferred reviewers for file paths, and a map of excluded file paths for reviewers.

--- a/bot/internal/review/review_test.go
+++ b/bot/internal/review/review_test.go
@@ -1265,6 +1265,8 @@ func TestGetCodeReviewers(t *testing.T) {
 				"4": {Owner: false, PreferredReviewerFor: []string{"lib/srv/app"}, PreferredOnly: true},
 				"5": {Owner: false, PreferredReviewerFor: []string{"lib/srv/db"}},
 				"6": {Owner: false},
+				"7": {Owner: true, PreferredReviewerFor: []string{"chart/teleport-operator", "!chart/teleport-operator/crds"}, PreferredOnly: true},
+				"8": {Owner: false, PreferredReviewerFor: []string{"chart/teleport-operator", "!chart/teleport-operator/crds"}, PreferredOnly: true},
 			},
 			Admins: []string{
 				"100",
@@ -1329,6 +1331,25 @@ func TestGetCodeReviewers(t *testing.T) {
 				{Name: "lib/srv/db/engine.go"},
 			},
 			expected: []string{"100", "200"},
+		},
+		{
+			description: "excluded paths only",
+			author:      "3",
+			files: []github.PullRequestFile{
+				{Name: "chart/teleport-operator/crds/teleport_v1alpha1_cluster.yaml"},
+				{Name: "chart/teleport-operator/crds/teleport_v1alpha1_node.yaml"},
+			},
+			expected: []string{"2", "5"},
+		},
+		{
+			description: "both excluded paths and non-excluded paths",
+			author:      "3",
+			files: []github.PullRequestFile{
+				{Name: "chart/teleport-operator/crds/teleport_v1alpha1_cluster.yaml"},
+				{Name: "chart/teleport-operator/crds/teleport_v1alpha1_node.yaml"},
+				{Name: "chart/teleport-operator/templates/configmap.yaml"},
+			},
+			expected: []string{"7", "8"},
 		},
 	}
 


### PR DESCRIPTION
We have cases where one directory contains both code we want to watch, and generated assets that are often changed and triggers noisy review requests.

This commit adds the ability to exclude paths from preferred reviews by prefixing them with `!`. Excluded paths always take precedence over included ones.